### PR TITLE
이슈 작성 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		8D1E5896248E2FCA002C2F3D /* IssueTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1E5895248E2FCA002C2F3D /* IssueTrackerTests.swift */; };
 		8D1E58A1248EE30F002C2F3D /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1E58A0248EE30F002C2F3D /* Issue.swift */; };
 		8D46A49C248F695500C0FFA3 /* IssueListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D46A49B248F695500C0FFA3 /* IssueListViewController.swift */; };
+		8D93E2A124927D2600A6BAE2 /* UIView+RoundedBorders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D93E2A024927D2600A6BAE2 /* UIView+RoundedBorders.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +59,7 @@
 		8D1E5897248E2FCA002C2F3D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1E58A0248EE30F002C2F3D /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		8D46A49B248F695500C0FFA3 /* IssueListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListViewController.swift; sourceTree = "<group>"; };
+		8D93E2A024927D2600A6BAE2 /* UIView+RoundedBorders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+RoundedBorders.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,13 +143,14 @@
 				6A676FC0248F720300FFA67E /* IssueDetail */,
 				8D17E5892491275E00F78815 /* NewIssue */,
 				8D17E58A24912EC500F78815 /* Constants.swift */,
+				8D93E2A224927D3C00A6BAE2 /* Extensions */,
 				8D1E5887248E2FCA002C2F3D /* Assets.xcassets */,
 				8D1E5881248E2FC7002C2F3D /* Main.storyboard */,
+				8D1E587B248E2FC7002C2F3D /* AppDelegate.swift */,
+				8D1E587D248E2FC7002C2F3D /* SceneDelegate.swift */,
 				8D1E5889248E2FCA002C2F3D /* LaunchScreen.storyboard */,
 				8D1E588C248E2FCA002C2F3D /* Info.plist */,
 				8D1E5884248E2FC7002C2F3D /* IssueTracker.xcdatamodeld */,
-				8D1E587B248E2FC7002C2F3D /* AppDelegate.swift */,
-				8D1E587D248E2FC7002C2F3D /* SceneDelegate.swift */,
 			);
 			path = IssueTracker;
 			sourceTree = "<group>";
@@ -159,6 +162,14 @@
 				8D1E5897248E2FCA002C2F3D /* Info.plist */,
 			);
 			path = IssueTrackerTests;
+			sourceTree = "<group>";
+		};
+		8D93E2A224927D3C00A6BAE2 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8D93E2A024927D2600A6BAE2 /* UIView+RoundedBorders.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -274,6 +285,7 @@
 				8D1E587E248E2FC7002C2F3D /* SceneDelegate.swift in Sources */,
 				6A676FBD248F71AC00FFA67E /* User.swift in Sources */,
 				8D17E58B24912EC500F78815 /* Constants.swift in Sources */,
+				8D93E2A124927D2600A6BAE2 /* UIView+RoundedBorders.swift in Sources */,
 				8D17E5882491274C00F78815 /* NewIssueViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		6A676FBF248F71B200FFA67E /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A676FBE248F71B200FFA67E /* Comment.swift */; };
 		6A676FC2248F723E00FFA67E /* IssueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A676FC1248F723E00FFA67E /* IssueCell.swift */; };
 		6A676FC4248F736F00FFA67E /* IssueListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A676FC3248F736F00FFA67E /* IssueListDataSource.swift */; };
-		8D17E5882491274C00F78815 /* NewIssueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D17E5872491274C00F78815 /* NewIssueViewController.swift */; };
+		8D17E5882491274C00F78815 /* IssueFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D17E5872491274C00F78815 /* IssueFormViewController.swift */; };
 		8D17E58B24912EC500F78815 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D17E58A24912EC500F78815 /* Constants.swift */; };
-		8D17E58D249131A400F78815 /* NewIssueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D17E58C249131A400F78815 /* NewIssueView.swift */; };
+		8D17E58D249131A400F78815 /* IssueFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D17E58C249131A400F78815 /* IssueFormView.swift */; };
 		8D1E587C248E2FC7002C2F3D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1E587B248E2FC7002C2F3D /* AppDelegate.swift */; };
 		8D1E587E248E2FC7002C2F3D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1E587D248E2FC7002C2F3D /* SceneDelegate.swift */; };
 		8D1E5880248E2FC7002C2F3D /* IssueDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1E587F248E2FC7002C2F3D /* IssueDetailViewController.swift */; };
@@ -42,9 +42,9 @@
 		6A676FBE248F71B200FFA67E /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		6A676FC1248F723E00FFA67E /* IssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCell.swift; sourceTree = "<group>"; };
 		6A676FC3248F736F00FFA67E /* IssueListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListDataSource.swift; sourceTree = "<group>"; };
-		8D17E5872491274C00F78815 /* NewIssueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewIssueViewController.swift; sourceTree = "<group>"; };
+		8D17E5872491274C00F78815 /* IssueFormViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFormViewController.swift; sourceTree = "<group>"; };
 		8D17E58A24912EC500F78815 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		8D17E58C249131A400F78815 /* NewIssueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewIssueView.swift; sourceTree = "<group>"; };
+		8D17E58C249131A400F78815 /* IssueFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFormView.swift; sourceTree = "<group>"; };
 		8D1E5878248E2FC7002C2F3D /* IssueTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IssueTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D1E587B248E2FC7002C2F3D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8D1E587D248E2FC7002C2F3D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -108,13 +108,13 @@
 			path = IssueDetail;
 			sourceTree = "<group>";
 		};
-		8D17E5892491275E00F78815 /* NewIssue */ = {
+		8D17E5892491275E00F78815 /* IssueForm */ = {
 			isa = PBXGroup;
 			children = (
-				8D17E5872491274C00F78815 /* NewIssueViewController.swift */,
-				8D17E58C249131A400F78815 /* NewIssueView.swift */,
+				8D17E5872491274C00F78815 /* IssueFormViewController.swift */,
+				8D17E58C249131A400F78815 /* IssueFormView.swift */,
 			);
-			path = NewIssue;
+			path = IssueForm;
 			sourceTree = "<group>";
 		};
 		8D1E586F248E2FC7002C2F3D = {
@@ -141,7 +141,7 @@
 				6A676FBA248F713F00FFA67E /* Model */,
 				6A676FBB248F715400FFA67E /* IssueList */,
 				6A676FC0248F720300FFA67E /* IssueDetail */,
-				8D17E5892491275E00F78815 /* NewIssue */,
+				8D17E5892491275E00F78815 /* IssueForm */,
 				8D17E58A24912EC500F78815 /* Constants.swift */,
 				8D93E2A224927D3C00A6BAE2 /* Extensions */,
 				8D1E5887248E2FCA002C2F3D /* Assets.xcassets */,
@@ -277,7 +277,7 @@
 				8D1E58A1248EE30F002C2F3D /* Issue.swift in Sources */,
 				8D1E5880248E2FC7002C2F3D /* IssueDetailViewController.swift in Sources */,
 				6A676FBF248F71B200FFA67E /* Comment.swift in Sources */,
-				8D17E58D249131A400F78815 /* NewIssueView.swift in Sources */,
+				8D17E58D249131A400F78815 /* IssueFormView.swift in Sources */,
 				8D1E587C248E2FC7002C2F3D /* AppDelegate.swift in Sources */,
 				6A676FC2248F723E00FFA67E /* IssueCell.swift in Sources */,
 				6A676FC4248F736F00FFA67E /* IssueListDataSource.swift in Sources */,
@@ -286,7 +286,7 @@
 				6A676FBD248F71AC00FFA67E /* User.swift in Sources */,
 				8D17E58B24912EC500F78815 /* Constants.swift in Sources */,
 				8D93E2A124927D2600A6BAE2 /* UIView+RoundedBorders.swift in Sources */,
-				8D17E5882491274C00F78815 /* NewIssueViewController.swift in Sources */,
+				8D17E5882491274C00F78815 /* IssueFormViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -38,6 +38,14 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZYp-jo-UqQ">
+                                <rect key="frame" x="321" y="20" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Edit"/>
+                                <connections>
+                                    <segue destination="QLA-dI-SMY" kind="show" destinationCreationSelector="showEditIssueWithCoder:" id="Joi-vM-t2l"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -53,11 +61,11 @@
             </objects>
             <point key="canvasLocation" x="1074.4000000000001" y="-447.04433497536945"/>
         </scene>
-        <!--New Issue View Controller-->
+        <!--Issue Form View Controller-->
         <scene sceneID="sqK-Wx-tFl">
             <objects>
-                <viewController id="QLA-dI-SMY" customClass="NewIssueViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="1Hx-Aw-G4K" customClass="NewIssueView" customModule="IssueTracker" customModuleProvider="target">
+                <viewController id="QLA-dI-SMY" customClass="IssueFormViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1Hx-Aw-G4K">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -68,12 +76,6 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Z6h-ka-vTd">
-                                <rect key="frame" x="21" y="130" width="338" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BJV-Hi-PMu">
                                 <rect key="frame" x="21" y="20" width="48" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -90,45 +92,62 @@
                                     <segue destination="FNo-bo-tQG" kind="unwind" identifier="CreatedSegue" unwindAction="newIssueDidCreated:" id="Qz5-9e-wvy"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Leave a comment below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDZ-7L-yfS">
-                                <rect key="frame" x="21" y="180" width="156" height="17"/>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hwr-FN-k6n" customClass="IssueFormView" customModule="IssueTracker" customModuleProvider="target">
+                                <rect key="frame" x="1" y="110" width="379" height="426"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="q7V-1r-0co">
-                                <rect key="frame" x="21" y="205" width="339" height="311"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Z6h-ka-vTd">
+                                        <rect key="frame" x="20" y="20" width="338" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Leave a comment below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDZ-7L-yfS">
+                                        <rect key="frame" x="20" y="70" width="156" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="q7V-1r-0co">
+                                        <rect key="frame" x="20" y="95" width="339" height="311"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="5"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </textView>
+                                </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                        <real key="value" value="1"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                        <color key="value" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="5"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </textView>
+                                <connections>
+                                    <outlet property="bodyTextView" destination="q7V-1r-0co" id="17I-ih-bDD"/>
+                                    <outlet property="titleTextField" destination="Z6h-ka-vTd" id="Rrr-SW-FUt"/>
+                                </connections>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="egX-DK-zmC"/>
-                        <connections>
-                            <outlet property="bodyTextView" destination="q7V-1r-0co" id="BGX-Us-Hj1"/>
-                            <outlet property="titleTextField" destination="Z6h-ka-vTd" id="aCI-5z-uzu"/>
-                        </connections>
                     </view>
+                    <navigationItem key="navigationItem" id="taM-aT-v1B"/>
+                    <connections>
+                        <outlet property="formView" destination="Hwr-FN-k6n" id="RyF-sg-PYR"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RNK-Zc-9cd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <exit id="FNo-bo-tQG" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="1072.8" y="254.92610837438426"/>
+            <point key="canvasLocation" x="169" y="336"/>
         </scene>
         <!--Issue List View Controller-->
         <scene sceneID="eSg-V6-B2u">
@@ -203,6 +222,9 @@
             <point key="canvasLocation" x="168.80000000000001" y="-447.78325123152712"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="Joi-vM-t2l"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
     </resources>

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -87,7 +87,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Save"/>
                                 <connections>
-                                    <segue destination="FNo-bo-tQG" kind="unwind" identifier="Save" unwindAction="newIssueDidSaved:" id="GWU-Uc-5i4"/>
+                                    <segue destination="FNo-bo-tQG" kind="unwind" unwindAction="newIssueDidCreated:" id="Qz5-9e-wvy"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Leave a comment below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDZ-7L-yfS">

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -188,7 +188,7 @@
                                         <connections>
                                             <outlet property="detailLabel" destination="ISi-i1-PHl" id="Y1w-Rv-ydy"/>
                                             <outlet property="titleLabel" destination="iuU-Eo-WD0" id="wHg-5K-B2Y"/>
-                                            <segue destination="BYZ-38-t0r" kind="show" id="lX8-TB-ZhA"/>
+                                            <segue destination="BYZ-38-t0r" kind="show" destinationCreationSelector="showDetailWithCoder:sender:" id="lX8-TB-ZhA"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -61,7 +61,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="새 이슈" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gob-Jf-JzZ">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="New Issue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gob-Jf-JzZ">
                                 <rect key="frame" x="21" y="58" width="166" height="41"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
@@ -74,14 +74,6 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="q7V-1r-0co">
-                                <rect key="frame" x="20" y="187" width="339" height="311"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BJV-Hi-PMu">
                                 <rect key="frame" x="21" y="20" width="48" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -98,6 +90,32 @@
                                     <segue destination="FNo-bo-tQG" kind="unwind" identifier="Save" unwindAction="newIssueDidSaved:" id="GWU-Uc-5i4"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Leave a comment below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDZ-7L-yfS">
+                                <rect key="frame" x="21" y="180" width="156" height="17"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="q7V-1r-0co">
+                                <rect key="frame" x="21" y="205" width="339" height="311"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="egX-DK-zmC"/>

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -87,7 +87,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Save"/>
                                 <connections>
-                                    <segue destination="FNo-bo-tQG" kind="unwind" unwindAction="newIssueDidCreated:" id="Qz5-9e-wvy"/>
+                                    <segue destination="FNo-bo-tQG" kind="unwind" identifier="CreatedSegue" unwindAction="newIssueDidCreated:" id="Qz5-9e-wvy"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Leave a comment below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDZ-7L-yfS">
@@ -187,7 +187,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                 <state key="normal" image="plus" catalog="system"/>
                                 <connections>
-                                    <segue destination="QLA-dI-SMY" kind="presentation" id="uCt-3O-ftf"/>
+                                    <segue destination="QLA-dI-SMY" kind="presentation" identifier="" id="uCt-3O-ftf"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/iOS/IssueTracker/IssueTracker/Constants.swift
+++ b/iOS/IssueTracker/IssueTracker/Constants.swift
@@ -5,6 +5,6 @@ enum SystemImageName {
 
 enum Identifier {
     enum Segue {
-        static let save = "Save"
+        static let save = "CreatedSegue"
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Extensions/UIView+RoundedBorders.swift
+++ b/iOS/IssueTracker/IssueTracker/Extensions/UIView+RoundedBorders.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+extension UIView {
+    @IBInspectable var borderWidth: CGFloat {
+        get { layer.borderWidth }
+        set { layer.borderWidth = newValue }
+    }
+
+    @IBInspectable var borderColor: UIColor? {
+        get { UIColor(cgColor: layer.borderColor!) }
+        set { layer.borderColor = newValue?.cgColor }
+    }
+
+    @IBInspectable var cornerRadius: CGFloat {
+        get { layer.cornerRadius }
+        set { layer.cornerRadius = newValue }
+    }
+
+}

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/IssueDetailViewController.swift
@@ -5,7 +5,16 @@ class IssueDetailViewController: UIViewController {
     @IBOutlet weak var bodyView: UITextView!
     @IBOutlet weak var ownerLabel: UILabel!
 
-    lazy var issue: Issue = .init(id: 1, title: "첫 번째 이슈", body: "이슈 한 바퀴 \n이슈 목록 만들기", owner: User(id: 1, name: "Jane Doe"))
+    var issue: Issue
+
+    init?(coder: NSCoder, issue: Issue) {
+        self.issue = issue
+        super.init(coder: coder)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOS/IssueTracker/IssueTracker/IssueDetail/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueDetail/IssueDetailViewController.swift
@@ -15,4 +15,11 @@ class IssueDetailViewController: UIViewController {
         ownerLabel.text = String(describing: issue.owner)
     }
 
+    // MARK: - Navigation
+
+    @IBSegueAction
+    private func showEditIssue(coder: NSCoder) -> IssueFormViewController? {
+        return IssueFormViewController(coder: coder, issue: issue)
+    }
+
 }

--- a/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormView.swift
@@ -1,10 +1,10 @@
 import UIKit
 
-class NewIssueView: UIView {
+class IssueFormView: UIView {
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var bodyTextView: UITextView!
 
-    var userInputData: (title: String, body: String) {
+    var userInput: (title: String, body: String) {
         (title: titleTextField.text ?? "", body: bodyTextView.text)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormView.swift
@@ -7,4 +7,22 @@ class IssueFormView: UIView {
     var userInput: (title: String, body: String) {
         (title: titleTextField.text ?? "", body: bodyTextView.text)
     }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        titleTextField.delegate = self
+    }
+
+}
+
+extension IssueFormView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        debugPrint(textField)
+        if textField == titleTextField {
+            debugPrint("titleTextField")
+            bodyTextView.becomeFirstResponder()
+        }
+
+        return true
+    }
 }

--- a/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormViewController.swift
@@ -1,16 +1,33 @@
 import UIKit
 
-class NewIssueViewController: UIViewController {
+class IssueFormViewController: UIViewController {
     typealias Texts = (title: String, body: String?)
+
+    @IBOutlet weak var formView: IssueFormView!
 
     private(set) var issue: Issue?
     private let user: User = .init(id: 1, name: "Foo")
-    private let issueID: ID = 1
+
+    init?(coder: NSCoder, issue: Issue?) {
+        self.issue = issue
+        super.init(coder: coder)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     // MARK: View Life Cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        configureFormView()
+    }
+
+    private func configureFormView() {
+        formView.titleTextField.text = issue?.title
+        formView.bodyTextView.text = issue?.body
     }
 
     // MARK: - Navigation
@@ -18,8 +35,7 @@ class NewIssueViewController: UIViewController {
     override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
         super.shouldPerformSegue(withIdentifier: identifier, sender: sender)
 
-        let view = self.view as! NewIssueView
-        if view.userInputData.title.isEmpty {
+        if formView.userInput.title.isEmpty {
             showMessage(for: .invalidNewIssueTitle)
             return false
         }
@@ -30,8 +46,7 @@ class NewIssueViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let identifier = segue.identifier, identifier == Identifier.Segue.save else { return }
 
-        let view = self.view as! NewIssueView
-        save(texts: view.userInputData)
+        save(texts: formView.userInput)
     }
 
     // MARK: - IBAction
@@ -51,7 +66,7 @@ class NewIssueViewController: UIViewController {
 
 // MARK: - Alert Message
 
-extension NewIssueViewController {
+extension IssueFormViewController {
     private func showMessage(for type: ValidateType) {
         let alert = makeAlert(for: type)
         present(alert, animated: false, completion: nil)
@@ -59,7 +74,7 @@ extension NewIssueViewController {
 
     private func makeAlert(for type: ValidateType) -> UIAlertController {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
-        (alert.title, alert.message) = type.message
+        (alert.title, alert.message) = type.content
 
         let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
         alert.addAction(defaultAction)
@@ -71,10 +86,12 @@ extension NewIssueViewController {
 enum ValidateType {
     case invalidNewIssueTitle
 
-    var message: (title: String, message: String) {
+    typealias Content = (title: String, message: String)
+
+    var content: Content {
         switch self {
         case .invalidNewIssueTitle:
-            return (title: "이슈 작성", message: "제목을 입력해야 합니다.")
+            return Content(title: "이슈 작성", message: "제목을 입력해야 합니다.")
         }
     }
 }

--- a/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormViewController.swift
@@ -14,7 +14,7 @@ class IssueFormViewController: UIViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
 
     // MARK: View Life Cycle

--- a/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueForm/IssueFormViewController.swift
@@ -58,7 +58,6 @@ class IssueFormViewController: UIViewController {
     // MARK: - Business Logic?
 
     private func save(texts: Texts) {
-        debugPrint(texts)
         self.issue = Issue(id: 1, title: texts.title, body: texts.body, owner: user)
     }
 

--- a/iOS/IssueTracker/IssueTracker/IssueList/IssueListDataSource.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/IssueListDataSource.swift
@@ -16,6 +16,10 @@ class IssueListDataSource: NSObject {
     func removeIssue(at index: IssueCollection.Index) {
         issueList.remove(at: index)
     }
+
+    func add(issue: Issue) {
+        issueList.append(issue)
+    }
 }
 
 extension IssueListDataSource: UITableViewDataSource {

--- a/iOS/IssueTracker/IssueTracker/IssueList/IssueListDataSource.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/IssueListDataSource.swift
@@ -20,6 +20,10 @@ class IssueListDataSource: NSObject {
     func add(issue: Issue) {
         issueList.append(issue)
     }
+
+    func issue(at index: Int) -> Issue {
+        return issueList[index]
+    }
 }
 
 extension IssueListDataSource: UITableViewDataSource {

--- a/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
@@ -20,12 +20,11 @@ class IssueListViewController: UIViewController {
     // MARK: - IBActions
 
     @IBAction func newIssueDidCreated(_ segue: UIStoryboardSegue) {
-        debugPrint("Detail ViewController")
         guard let newIssueViewController = segue.source as? NewIssueViewController,
-            let issue = newIssueViewController.issue
-            else { return }
+            let issue = newIssueViewController.issue else { return }
 
-        debugPrint(issue)
+        dataSource.add(issue: issue)
+        tableView.reloadData()
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
@@ -20,8 +20,8 @@ class IssueListViewController: UIViewController {
     // MARK: - IBActions
 
     @IBAction func newIssueDidCreated(_ segue: UIStoryboardSegue) {
-        guard let newIssueViewController = segue.source as? NewIssueViewController,
-            let issue = newIssueViewController.issue else { return }
+        guard let viewController = segue.source as? IssueFormViewController,
+            let issue = viewController.issue else { return }
 
         dataSource.add(issue: issue)
         tableView.reloadData()

--- a/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
@@ -17,7 +17,7 @@ class IssueListViewController: UIViewController {
         tableView.delegate = self
     }
 
-    // MARK: - IBActions
+    // MARK: - Navigation
 
     @IBAction func newIssueDidCreated(_ segue: UIStoryboardSegue) {
         guard let viewController = segue.source as? IssueFormViewController,
@@ -25,6 +25,13 @@ class IssueListViewController: UIViewController {
 
         dataSource.add(issue: issue)
         tableView.reloadData()
+    }
+
+    @IBSegueAction func showDetail(coder: NSCoder, sender: IssueCell) -> IssueDetailViewController? {
+        guard let indexPath = tableView.indexPathForSelectedRow else { return nil }
+
+        let issue = dataSource.issue(at: indexPath.row)
+        return IssueDetailViewController(coder: coder, issue: issue)
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/IssueList/IssueListViewController.swift
@@ -19,7 +19,7 @@ class IssueListViewController: UIViewController {
 
     // MARK: - IBActions
 
-    @IBAction func newIssueDidSaved(_ segue: UIStoryboardSegue) {
+    @IBAction func newIssueDidCreated(_ segue: UIStoryboardSegue) {
         debugPrint("Detail ViewController")
         guard let newIssueViewController = segue.source as? NewIssueViewController,
             let issue = newIssueViewController.issue

--- a/iOS/IssueTracker/IssueTracker/NewIssue/NewIssueView.swift
+++ b/iOS/IssueTracker/IssueTracker/NewIssue/NewIssueView.swift
@@ -3,4 +3,8 @@ import UIKit
 class NewIssueView: UIView {
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var bodyTextView: UITextView!
+
+    var userInputData: (title: String, body: String) {
+        (title: titleTextField.text ?? "", body: bodyTextView.text)
+    }
 }

--- a/iOS/IssueTracker/IssueTracker/NewIssue/NewIssueViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/NewIssue/NewIssueViewController.swift
@@ -7,23 +7,24 @@ class NewIssueViewController: UIViewController {
     private let user: User = .init(id: 1, name: "Foo")
     private let issueID: ID = 1
 
+    // MARK: View Life Cycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }
 
+    // MARK: - Segue Action
+
     override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
         super.shouldPerformSegue(withIdentifier: identifier, sender: sender)
 
-        debugPrint("Segue identifier: \(identifier)")
-        debugPrint(#file, #function)
-        // TODO: 입력 텍스트 유효성 검사
+        let view = self.view as! NewIssueView
+        if let text = view.titleTextField.text, text.isEmpty {
+            showMessage(for: .invalidNewIssueTitle)
+            return false
+        }
+
         return true
-    }
-
-    // MARK: - IBActions
-
-    @IBAction func cancelTouched(_ sender: UIButton) {
-        dismiss(animated: true, completion: nil)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -33,10 +34,46 @@ class NewIssueViewController: UIViewController {
         save(texts: texts)
     }
 
+    // MARK: - IBAction
+
+    @IBAction func cancelTouched(_ sender: UIButton) {
+        dismiss(animated: true, completion: nil)
+    }
+
     // MARK: - Business Logic?
 
     private func save(texts: Texts) {
         self.issue = Issue(id: 1, title: texts.title, body: texts.body, owner: user)
     }
 
+}
+
+// MARK: - Alert Message
+
+extension NewIssueViewController {
+    private func showMessage(for type: ValidateType) {
+        let alert = makeAlert(for: type)
+        present(alert, animated: false, completion: nil)
+    }
+
+    private func makeAlert(for type: ValidateType) -> UIAlertController {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
+        (alert.title, alert.message) = type.message
+
+        let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alert.addAction(defaultAction)
+
+        return alert
+    }
+}
+
+enum ValidateType {
+    case invalidNewIssueTitle
+
+    var message: (title: String, message: String) {
+        switch self {
+        case .invalidNewIssueTitle:
+            return (title: "이슈 작성", message: "제목을 입력해야 합니다.")
+        }
+    }
 }

--- a/iOS/IssueTracker/IssueTracker/NewIssue/NewIssueViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/NewIssue/NewIssueViewController.swift
@@ -13,13 +13,13 @@ class NewIssueViewController: UIViewController {
         super.viewDidLoad()
     }
 
-    // MARK: - Segue Action
+    // MARK: - Navigation
 
     override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
         super.shouldPerformSegue(withIdentifier: identifier, sender: sender)
 
         let view = self.view as! NewIssueView
-        if let text = view.titleTextField.text, text.isEmpty {
+        if view.userInputData.title.isEmpty {
             showMessage(for: .invalidNewIssueTitle)
             return false
         }
@@ -30,8 +30,8 @@ class NewIssueViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let identifier = segue.identifier, identifier == Identifier.Segue.save else { return }
 
-        let texts: Texts = (title: "Test title", body: "body text test")
-        save(texts: texts)
+        let view = self.view as! NewIssueView
+        save(texts: view.userInputData)
     }
 
     // MARK: - IBAction
@@ -43,6 +43,7 @@ class NewIssueViewController: UIViewController {
     // MARK: - Business Logic?
 
     private func save(texts: Texts) {
+        debugPrint(texts)
         self.issue = Issue(id: 1, title: texts.title, body: texts.body, owner: user)
     }
 


### PR DESCRIPTION
## 요약
- IssueDetailViewController: 이슈 상세 보기 화면
- IssueFormViewController: 이슈 작성 화면
- IssueFormView: userInput을 반환할 수 있게 했어요. TextField의 delegate 역할을 해요.
- extension UIView: 외곽선 구현. IB에서 조절할 수는 있으나 IB에 렌더링되지 않음.

## 기타
- 하드코딩으로 되어 있는 모델은 `dev-ios`와 합친 후, StateController를 사용하여 연결할 거에요.
- `@IBSegueAction`을 사용해 봤어요. `prepare()`보다 장점이 많아요.
- Alert Message 분리: AlertController를 생성하는 것과 표시할 메시지를 분리했어요.
