### PR TITLE
1주차 피드백을 반영하여 빈 사용자에 Null Object Pattern을 적용한다.

### DIFF
--- a/BE/src/main/java/com/codesquad/issue04/config/auth/CustomOAuth2UserService.java
+++ b/BE/src/main/java/com/codesquad/issue04/config/auth/CustomOAuth2UserService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 
 import com.codesquad.issue04.config.dto.OAuthAttributes;
 import com.codesquad.issue04.config.dto.SessionUser;
-import com.codesquad.issue04.domain.user.User;
+import com.codesquad.issue04.domain.user.RealUser;
 import com.codesquad.issue04.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -34,8 +34,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
 		String userNameAttributename = userRequest.getClientRegistration().getProviderDetails()
 			.getUserInfoEndpoint().getUserNameAttributeName();
-		OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributename, oAuth2User.getAttributes());
-		User user = saveOrUpdate(attributes);
+		OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributename,
+			oAuth2User.getAttributes());
+		RealUser user = saveOrUpdate(attributes);
 		httpSession.setAttribute("user", new SessionUser(user));
 
 		return new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey())),
@@ -43,12 +44,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 			attributes.getNameAttributeKey());
 	}
 
-	private User saveOrUpdate(OAuthAttributes attributes) {
+	private RealUser saveOrUpdate(OAuthAttributes attributes) {
 
-		User user = userRepository.findByGithubId(attributes.getGithubId())
+		RealUser realUser = userRepository.findByGithubId(attributes.getGithubId())
 			.map(entity -> entity.update(attributes.getName(), attributes.getImage()))
 			.orElse(attributes.toEntity());
 
-		return userRepository.save(user);
+		return userRepository.save(realUser);
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/config/dto/OAuthAttributes.java
+++ b/BE/src/main/java/com/codesquad/issue04/config/dto/OAuthAttributes.java
@@ -3,8 +3,8 @@ package com.codesquad.issue04.config.dto;
 import java.util.Map;
 import java.util.Optional;
 
+import com.codesquad.issue04.domain.user.RealUser;
 import com.codesquad.issue04.domain.user.Role;
-import com.codesquad.issue04.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -34,7 +34,7 @@ public class OAuthAttributes {
 
 	private static OAuthAttributes ofGithub(String userNameAttributeName, Map<String, Object> attributes) {
 		return OAuthAttributes.builder()
-			.name((String)Optional.ofNullable(attributes.get("name")).orElse(attributes.get("login")))
+			.name((String) Optional.ofNullable(attributes.get("name")).orElse(attributes.get("login")))
 			.githubId((String) attributes.get("login"))
 			.image((String) attributes.get("avatar_url"))
 			.attributes(attributes)
@@ -42,8 +42,8 @@ public class OAuthAttributes {
 			.build();
 	}
 
-	public User toEntity() {
-		return User.builder()
+	public RealUser toEntity() {
+		return RealUser.builder()
 			.name(name)
 			.githubId(githubId)
 			.image(image)

--- a/BE/src/main/java/com/codesquad/issue04/config/dto/SessionUser.java
+++ b/BE/src/main/java/com/codesquad/issue04/config/dto/SessionUser.java
@@ -2,7 +2,7 @@ package com.codesquad.issue04.config.dto;
 
 import java.io.Serializable;
 
-import com.codesquad.issue04.domain.user.User;
+import com.codesquad.issue04.domain.user.RealUser;
 import lombok.Getter;
 
 @Getter
@@ -12,7 +12,7 @@ public class SessionUser implements Serializable {
 	private String githubId;
 	private String image;
 
-	public SessionUser(User user) {
+	public SessionUser(RealUser user) {
 		this.name = user.getName();
 		this.githubId = user.getGithubId();
 		this.image = user.getImage();

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Comment.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Comment.java
@@ -21,7 +21,7 @@ import javax.persistence.ManyToOne;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
-import com.codesquad.issue04.domain.user.User;
+import com.codesquad.issue04.domain.user.RealUser;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -62,7 +62,7 @@ public class Comment implements Serializable {
 
 	@ManyToOne
 	@JoinColumn(foreignKey = @ForeignKey(name = "user_id"))
-	private User user;
+	private RealUser user;
 
 	@JsonIgnore
 	@ManyToOne

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -35,41 +35,40 @@ import lombok.ToString;
 @Entity
 public class Issue {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    private String title;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String title;
 
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "issue", cascade = CascadeType.REMOVE)
-    private List<Comment> comments;
+	@OneToMany(fetch = FetchType.EAGER, mappedBy = "issue", cascade = CascadeType.REMOVE)
+	private List<Comment> comments;
 
-    @ManyToMany(fetch = FetchType.EAGER)
-    @JoinTable(
-        name = "label_has_issue",
-        joinColumns = @JoinColumn(name = "issue_id"),
-        inverseJoinColumns = @JoinColumn(name = "label_id")
-    )
-    private Set<Label> labels;
+	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(
+		name = "label_has_issue",
+		joinColumns = @JoinColumn(name = "issue_id"),
+		inverseJoinColumns = @JoinColumn(name = "label_id")
+	)
+	private Set<Label> labels;
 
-    @ManyToOne
-    @JoinColumn(foreignKey = @ForeignKey(name = "milestone_id"))
-    private Milestone milestone;
+	@ManyToOne
+	@JoinColumn(foreignKey = @ForeignKey(name = "milestone_id"))
+	private Milestone milestone;
 
-    @ManyToOne
-    @JoinColumn(foreignKey = @ForeignKey(name = "user_id"))
-    private RealUser user;
+	@ManyToOne
+	@JoinColumn(foreignKey = @ForeignKey(name = "user_id"))
+	private RealUser user;
 
-    @Builder
-    public Issue(Long id, String title, List<Comment> comments,
-        Set<Label> labels, Milestone milestone, RealUser user) {
+	@Builder
+	public Issue(Long id, String title, List<Comment> comments,
+		Set<Label> labels, Milestone milestone, RealUser user) {
 
-        this.id = id;
-        this.title = Optional.ofNullable(title).orElse("직박구리");
-        this.comments = Optional.ofNullable(comments).orElse(Collections.emptyList());
-        this.labels = Optional.ofNullable(labels).orElse(Collections.emptySet());
-        this.milestone = Optional.ofNullable(milestone).orElse(new Milestone());
-        this.user = Optional.ofNullable(user).orElse(NullUser.of());
-    }
-
+		this.id = id;
+		this.title = Optional.ofNullable(title).orElse("직박구리");
+		this.comments = Optional.ofNullable(comments).orElse(Collections.emptyList());
+		this.labels = Optional.ofNullable(labels).orElse(Collections.emptySet());
+		this.milestone = Optional.ofNullable(milestone).orElse(new Milestone());
+		this.user = Optional.ofNullable(user).orElse(NullUser.of());
+	}
 
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -20,6 +20,7 @@ import javax.persistence.OneToMany;
 
 import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
+import com.codesquad.issue04.domain.milestone.NullMilestone;
 import com.codesquad.issue04.domain.user.NullUser;
 import com.codesquad.issue04.domain.user.RealUser;
 import lombok.Builder;
@@ -67,7 +68,7 @@ public class Issue {
 		this.title = Optional.ofNullable(title).orElse("직박구리");
 		this.comments = Optional.ofNullable(comments).orElse(Collections.emptyList());
 		this.labels = Optional.ofNullable(labels).orElse(Collections.emptySet());
-		this.milestone = Optional.ofNullable(milestone).orElse(new Milestone());
+		this.milestone = Optional.ofNullable(milestone).orElse(NullMilestone.of());
 		this.user = Optional.ofNullable(user).orElse(NullUser.of());
 	}
 

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -20,9 +20,8 @@ import javax.persistence.OneToMany;
 
 import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
-import com.codesquad.issue04.domain.user.User;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import com.codesquad.issue04.domain.user.NullUser;
+import com.codesquad.issue04.domain.user.RealUser;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -58,18 +57,18 @@ public class Issue {
 
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "user_id"))
-    private User user;
+    private RealUser user;
 
     @Builder
     public Issue(Long id, String title, List<Comment> comments,
-        Set<Label> labels, Milestone milestone, User user) {
+        Set<Label> labels, Milestone milestone, RealUser user) {
 
         this.id = id;
         this.title = Optional.ofNullable(title).orElse("직박구리");
         this.comments = Optional.ofNullable(comments).orElse(Collections.emptyList());
         this.labels = Optional.ofNullable(labels).orElse(Collections.emptySet());
         this.milestone = Optional.ofNullable(milestone).orElse(new Milestone());
-        this.user = Optional.ofNullable(user).orElse(User.builder().name("존재하지 않는 사용자입니다.").build());
+        this.user = Optional.ofNullable(user).orElse(NullUser.of());
     }
 
 

--- a/BE/src/main/java/com/codesquad/issue04/domain/milestone/AbstractMilestone.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/milestone/AbstractMilestone.java
@@ -1,0 +1,5 @@
+package com.codesquad.issue04.domain.milestone;
+
+public interface AbstractMilestone {
+	boolean isNil();
+}

--- a/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 @Builder
-public class Milestone {
+public class Milestone implements AbstractMilestone {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,4 +34,9 @@ public class Milestone {
 
 	@OneToMany(mappedBy = "milestone")
 	private List<Issue> issues;
+
+	@Override
+	public boolean isNil() {
+		return false;
+	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/milestone/NullMilestone.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/milestone/NullMilestone.java
@@ -1,0 +1,23 @@
+package com.codesquad.issue04.domain.milestone;
+
+import lombok.Getter;
+
+@Getter
+public class NullMilestone extends Milestone implements AbstractMilestone {
+
+	private static String NULL_MILESTONE_MESSAGE = "빈 마일스톤입니다.";
+	private String title;
+
+	private NullMilestone() {
+		this.title = NULL_MILESTONE_MESSAGE;
+	}
+
+	public static NullMilestone of() {
+		return new NullMilestone();
+	}
+
+	@Override
+	public boolean isNil() {
+		return true;
+	}
+}

--- a/BE/src/main/java/com/codesquad/issue04/domain/user/AbstractUser.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/user/AbstractUser.java
@@ -1,0 +1,18 @@
+package com.codesquad.issue04.domain.user;
+
+import java.util.List;
+
+import com.codesquad.issue04.domain.issue.Issue;
+import lombok.Getter;
+
+@Getter
+public abstract class AbstractUser {
+	protected Long id;
+	protected String name;
+	protected String githubId;
+	protected String image;
+	protected List<Issue> issues;
+	protected Role role;
+
+	public abstract boolean isNil();
+}

--- a/BE/src/main/java/com/codesquad/issue04/domain/user/AbstractUser.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/user/AbstractUser.java
@@ -1,18 +1,5 @@
 package com.codesquad.issue04.domain.user;
 
-import java.util.List;
-
-import com.codesquad.issue04.domain.issue.Issue;
-import lombok.Getter;
-
-@Getter
-public abstract class AbstractUser {
-	protected Long id;
-	protected String name;
-	protected String githubId;
-	protected String image;
-	protected List<Issue> issues;
-	protected Role role;
-
-	public abstract boolean isNil();
+public interface AbstractUser {
+	boolean isNil();
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/user/NullUser.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/user/NullUser.java
@@ -1,0 +1,23 @@
+package com.codesquad.issue04.domain.user;
+
+import lombok.Getter;
+
+@Getter
+public class NullUser extends RealUser implements AbstractUser {
+
+	private static String NULL_USER_MESSAGE = "존재하지 않는 사용자입니다.";
+	private String name;
+
+	private NullUser() {
+		this.name = "존재하지 않는 사용자입니다.";
+	}
+
+	public static NullUser of() {
+		return new NullUser();
+	}
+
+	@Override
+	public boolean isNil() {
+		return true;
+	}
+}

--- a/BE/src/main/java/com/codesquad/issue04/domain/user/RealUser.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/user/RealUser.java
@@ -12,6 +12,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 import com.codesquad.issue04.domain.issue.Issue;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -28,7 +29,8 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Entity
-public class User extends AbstractUser implements Serializable {
+@Table(name = "user")
+public class RealUser implements Serializable, AbstractUser {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,7 +49,7 @@ public class User extends AbstractUser implements Serializable {
     @Column(name = "role_key")
     private Role role;
 
-    public User update(String name, String picture) {
+    public RealUser update(String name, String picture) {
         this.name = name;
         this.image = picture;
         return this;

--- a/BE/src/main/java/com/codesquad/issue04/domain/user/User.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/user/User.java
@@ -28,7 +28,7 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Entity
-public class User implements Serializable {
+public class User extends AbstractUser implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,5 +51,10 @@ public class User implements Serializable {
         this.name = name;
         this.image = picture;
         return this;
+    }
+
+    @Override
+    public boolean isNil() {
+        return false;
     }
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/user/UserRepository.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/user/UserRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<RealUser, Long> {
 
-	Optional<User> findByGithubId(String githubId);
+	Optional<RealUser> findByGithubId(String githubId);
 }

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueDetailResponseDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueDetailResponseDto.java
@@ -7,7 +7,7 @@ import com.codesquad.issue04.domain.issue.Comment;
 import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
-import com.codesquad.issue04.domain.user.User;
+import com.codesquad.issue04.domain.user.RealUser;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +23,7 @@ public class IssueDetailResponseDto {
 	private List<Comment> comments;
 	private Set<Label> labels;
 	private Milestone milestone;
-	private User user;
+	private RealUser realUser;
 
 	@Builder
 	public IssueDetailResponseDto(Issue issue) {
@@ -33,7 +33,7 @@ public class IssueDetailResponseDto {
 		this.comments = issue.getComments();
 		this.labels = issue.getLabels();
 		this.milestone = issue.getMilestone();
-		this.user = issue.getUser();
+		this.realUser = issue.getUser();
 	}
 
 	public static IssueDetailResponseDto of(Issue issue) {

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueOverviewDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueOverviewDto.java
@@ -10,7 +10,7 @@ import com.codesquad.issue04.domain.issue.Comment;
 import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
-import com.codesquad.issue04.domain.user.User;
+import com.codesquad.issue04.domain.user.RealUser;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,7 +35,7 @@ public class IssueOverviewDto {
 		List<Comment> comments = Optional.ofNullable(issue.getComments()).orElse(new ArrayList<>());
 		Milestone milestone = issue.getMilestone();
 		Set<Label> labels = issue.getLabels();
-		User user = issue.getUser();
+		RealUser realUser = issue.getUser();
 
 		this.id = issue.getId();
 		this.title = issue.getTitle();
@@ -45,7 +45,7 @@ public class IssueOverviewDto {
 		this.labelTitles = labels.stream()
 			.map(Label::getTitle)
 			.collect(Collectors.toSet());
-		this.githubId = user.getGithubId();
+		this.githubId = realUser.getGithubId();
 	}
 
 	public static IssueOverviewDto of(Issue issue) {

--- a/BE/src/test/java/com/codesquad/issue04/domain/issue/IssueTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/domain/issue/IssueTest.java
@@ -10,22 +10,22 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.codesquad.issue04.domain.milestone.Milestone;
-import com.codesquad.issue04.domain.user.User;
+import com.codesquad.issue04.domain.user.RealUser;
 
 @SpringBootTest
 public class IssueTest {
 
-	private User user;
+	private RealUser user;
 
 	@BeforeEach
 	void setUp() {
-		this.user = User.builder()
-		.id(1L)
-		.githubId("guswns1659")
-		.image("image")
-		.name("Jack")
-		.issues(Collections.emptyList())
-		.build();
+		this.user = RealUser.builder()
+			.id(1L)
+			.githubId("guswns1659")
+			.image("image")
+			.name("Jack")
+			.issues(Collections.emptyList())
+			.build();
 	}
 
 	@DisplayName("Null인 필드의 빈 객체를 반환한다.")

--- a/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
@@ -73,7 +73,7 @@ public class IssueServiceTest {
 
 		assertThat(issueDetailResponseDto.getId()).isEqualTo(id);
 		assertThat(issueDetailResponseDto.getTitle()).isEqualTo(title);
-		assertThat(issueDetailResponseDto.getUser().getIssues().size()).isGreaterThan(0);
+		assertThat(issueDetailResponseDto.getRealUser().getIssues().size()).isGreaterThan(0);
 	}
 
 }


### PR DESCRIPTION
## 반영한 사항
* [x] Issue 객체에서 빈 사용자를 저장할 때 RealUser를 extend한 NullUser를 삽입
* [x] Issue 객체에서 빈 마일스톤을 저장할 때 Milestone을 extend한 NullMilestone을 삽입

## 참고 링크
* https://johngrib.github.io/wiki/null-object-pattern/
* https://kunoo.tistory.com/entry/%ED%96%89%EC%9C%84-%ED%8C%A8%ED%84%B4-Null-Object-pattern-%EB%84%90-%EC%98%A4%EB%B8%8C%EC%A0%9D%ED%8A%B8-%ED%8C%A8%ED%84%B4
* https://www.slideshare.net/gyumee/null-142590829