### PR TITLE
이슈의 열린 상태, 닫힌 상태를 추가하고 이를 바탕으로 필터링하는 API를 제공한다.

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: '2.3.0.RELEASE'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -7,6 +7,8 @@ import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
@@ -60,6 +62,9 @@ public class Issue {
 	@JoinColumn(foreignKey = @ForeignKey(name = "user_id"))
 	private RealUser user;
 
+	@Enumerated(EnumType.STRING)
+	private Status status;
+
 	@Builder
 	public Issue(Long id, String title, List<Comment> comments,
 		Set<Label> labels, Milestone milestone, RealUser user) {
@@ -72,4 +77,29 @@ public class Issue {
 		this.user = Optional.ofNullable(user).orElse(NullUser.of());
 	}
 
+	public boolean isOpen() {
+		return this.status == Status.OPEN;
+	}
+
+	public boolean isClosed() {
+		return this.status == Status.CLOSED;
+	}
+
+	public Status changeStatusToOpen() {
+		if (this.status.isOpen()) {
+			throw new IllegalArgumentException("this issue is already opened.");
+		}
+		Status openStatus = Status.OPEN;
+		this.status = openStatus;
+		return openStatus;
+	}
+
+	public Status changeStatusToClosed() {
+		if (! this.status.isOpen()) {
+			throw new IllegalArgumentException("this issue is already closed.");
+		}
+		Status closedStatus = Status.CLOSED;
+		this.status = closedStatus;
+		return closedStatus;
+	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Status.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Status.java
@@ -1,0 +1,17 @@
+package com.codesquad.issue04.domain.issue;
+
+import lombok.Getter;
+
+@Getter
+public enum Status {
+	OPEN("open", true),
+	CLOSED("closed", false);
+
+	private String name;
+	private boolean open;
+
+	Status(String name, boolean open) {
+		this.name = name;
+		this.open = open;
+	}
+}

--- a/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
@@ -34,13 +34,41 @@ public class IssueService {
 			.collect(Collectors.toList());
 	}
 
+	List<IssueOverviewDto> findAllOpenIssuesOverview() {
+		List<Issue> issues = findAllIssues();
+		return issues.stream()
+			.filter(Issue::isOpen)
+			.map(IssueOverviewDto::of)
+			.collect(Collectors.toList());
+	}
+
+	List<IssueOverviewDto> findAllClosedIssuesOverview() {
+		List<Issue> issues = findAllIssues();
+		return issues.stream()
+			.filter(Issue::isClosed)
+			.map(IssueOverviewDto::of)
+			.collect(Collectors.toList());
+	}
+
 	public IssueDetailResponseDto findIssueDetailById(Long issueId) {
 		return IssueDetailResponseDto.of(findIssueById(issueId));
 	}
 
-	public IssueOverviewResponseDtos getIssueOverviews() {
+	public IssueOverviewResponseDtos getAllIssueOverviews() {
 		return IssueOverviewResponseDtos.builder()
 			.allData(findAllIssuesOverview())
+			.build();
+	}
+
+	public IssueOverviewResponseDtos getOpenIssueOverviews() {
+		return IssueOverviewResponseDtos.builder()
+			.allData(findAllOpenIssuesOverview())
+			.build();
+	}
+
+	public IssueOverviewResponseDtos getClosedIssueOverviews() {
+		return IssueOverviewResponseDtos.builder()
+			.allData(findAllClosedIssuesOverview())
 			.build();
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/web/controller/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/controller/IssueController.java
@@ -1,20 +1,39 @@
 package com.codesquad.issue04.web.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.codesquad.issue04.domain.issue.Status;
 import com.codesquad.issue04.service.IssueService;
-import com.codesquad.issue04.web.dto.response.issue.IssueOverviewResponseDtos;
+import com.codesquad.issue04.web.dto.response.ResponseDto;
+import com.codesquad.issue04.web.dto.response.error.ErrorResponseDto;
 import lombok.AllArgsConstructor;
 
 @RestController
+@RequestMapping("/api/v1/issues")
 @AllArgsConstructor
 public class IssueController {
 
 	private final IssueService issueService;
 
-	@GetMapping("api/v1/issues")
-	public IssueOverviewResponseDtos getIssues() {
-		return issueService.getIssueOverviews();
+	@GetMapping
+	public ResponseEntity<ResponseDto> getIssues(@RequestParam(value = "status", defaultValue = "all") String status) {
+		final String ALL_ISSUES = "all";
+		if (status.equals(Status.OPEN.getName())) {
+			return new ResponseEntity<>(issueService.getOpenIssueOverviews(), HttpStatus.OK);
+		}
+		if (status.equals(Status.CLOSED.getName())) {
+			return new ResponseEntity<>(issueService.getClosedIssueOverviews(), HttpStatus.OK);
+		}
+		if (status.equals(ALL_ISSUES)) {
+			return new ResponseEntity<>(issueService.getAllIssueOverviews(), HttpStatus.OK);
+		}
+		return new ResponseEntity<>(
+			new ErrorResponseDto(HttpStatus.NOT_ACCEPTABLE.value(), new RuntimeException("wrong input but check")),
+			HttpStatus.NOT_ACCEPTABLE);
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/ResponseDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/ResponseDto.java
@@ -1,0 +1,4 @@
+package com.codesquad.issue04.web.dto.response;
+
+public interface ResponseDto {
+}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/error/ErrorResponseDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/error/ErrorResponseDto.java
@@ -1,0 +1,19 @@
+package com.codesquad.issue04.web.dto.response.error;
+
+import java.io.Serializable;
+
+import com.codesquad.issue04.web.dto.response.ResponseDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ErrorResponseDto implements ResponseDto, Serializable {
+	private int code;
+	private String message;
+
+	public ErrorResponseDto(int code, Exception exception) {
+		this.code = code;
+		this.message = exception.getMessage();
+	}
+}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueDetailResponseDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueDetailResponseDto.java
@@ -5,9 +5,11 @@ import java.util.Set;
 
 import com.codesquad.issue04.domain.issue.Comment;
 import com.codesquad.issue04.domain.issue.Issue;
+import com.codesquad.issue04.domain.issue.Status;
 import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
 import com.codesquad.issue04.domain.user.RealUser;
+import com.codesquad.issue04.web.dto.response.ResponseDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +18,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor
-public class IssueDetailResponseDto {
+public class IssueDetailResponseDto implements ResponseDto {
 
 	private Long id;
 	private String title;
@@ -24,6 +26,7 @@ public class IssueDetailResponseDto {
 	private Set<Label> labels;
 	private Milestone milestone;
 	private RealUser realUser;
+	private Status status;
 
 	@Builder
 	public IssueDetailResponseDto(Issue issue) {
@@ -34,6 +37,7 @@ public class IssueDetailResponseDto {
 		this.labels = issue.getLabels();
 		this.milestone = issue.getMilestone();
 		this.realUser = issue.getUser();
+		this.status = issue.getStatus();
 	}
 
 	public static IssueDetailResponseDto of(Issue issue) {

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueOverviewDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueOverviewDto.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import com.codesquad.issue04.domain.issue.Comment;
 import com.codesquad.issue04.domain.issue.Issue;
+import com.codesquad.issue04.domain.issue.Status;
 import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
 import com.codesquad.issue04.domain.user.RealUser;
@@ -28,6 +29,7 @@ public class IssueOverviewDto {
 	private String mileStonesTitle;
 	private Set<String> labelTitles;
 	private String githubId;
+	private Status status;
 
 	@Builder
 	public IssueOverviewDto(Issue issue) {
@@ -46,6 +48,7 @@ public class IssueOverviewDto {
 			.map(Label::getTitle)
 			.collect(Collectors.toSet());
 		this.githubId = realUser.getGithubId();
+		this.status = issue.getStatus();
 	}
 
 	public static IssueOverviewDto of(Issue issue) {

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueOverviewResponseDtos.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueOverviewResponseDtos.java
@@ -2,6 +2,7 @@ package com.codesquad.issue04.web.dto.response.issue;
 
 import java.util.List;
 
+import com.codesquad.issue04.web.dto.response.ResponseDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +15,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class IssueOverviewResponseDtos {
+public class IssueOverviewResponseDtos implements ResponseDto {
 
 	private List<IssueOverviewDto> allData;
 }

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/label/LabelOverviewResponseDtos.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/label/LabelOverviewResponseDtos.java
@@ -2,6 +2,7 @@ package com.codesquad.issue04.web.dto.response.label;
 
 import java.util.List;
 
+import com.codesquad.issue04.web.dto.response.ResponseDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +15,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class LabelOverviewResponseDtos {
+public class LabelOverviewResponseDtos implements ResponseDto {
 
 	private List<LabelOverviewDto> allData;
 }

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/label/MilestoneResponseDtos.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/label/MilestoneResponseDtos.java
@@ -2,6 +2,7 @@ package com.codesquad.issue04.web.dto.response.label;
 
 import java.util.List;
 
+import com.codesquad.issue04.web.dto.response.ResponseDto;
 import com.codesquad.issue04.web.dto.response.milestone.MilestoneResponseDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,7 +16,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class MilestoneResponseDtos {
+public class MilestoneResponseDtos implements ResponseDto {
 	private List<MilestoneResponseDto> allData;
 
 }

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/milestone/MilestoneResponseDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/milestone/MilestoneResponseDto.java
@@ -3,10 +3,11 @@ package com.codesquad.issue04.web.dto.response.milestone;
 import java.time.LocalDateTime;
 
 import com.codesquad.issue04.domain.milestone.Milestone;
+import com.codesquad.issue04.web.dto.response.ResponseDto;
 import lombok.Getter;
 
 @Getter
-public class MilestoneResponseDto {
+public class MilestoneResponseDto implements ResponseDto {
 	private Long id;
 	private String title;
 	private LocalDateTime dueDate;

--- a/BE/src/main/resources/db/migration/V1__CreateTable.sql
+++ b/BE/src/main/resources/db/migration/V1__CreateTable.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS milestone
 CREATE TABLE IF NOT EXISTS issue
 (
     id           INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    title        VARCHAR(45)                    NULL,
+    title        VARCHAR(45)                    NOT NULL,
+    status       VARCHAR(45)                    NOT NULL DEFAULT 'OPEN',
     user_id      INT                            NOT NULL,
     milestone_id INT                            NOT NULL,
     CONSTRAINT fk_issue_user FOREIGN KEY (user_id) REFERENCES user (id),

--- a/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.codesquad.issue04.domain.issue.Issue;
+import com.codesquad.issue04.domain.issue.Status;
 import com.codesquad.issue04.web.dto.response.issue.IssueDetailResponseDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueOverviewDto;
 
@@ -76,4 +77,46 @@ public class IssueServiceTest {
 		assertThat(issueDetailResponseDto.getRealUser().getIssues().size()).isGreaterThan(0);
 	}
 
+	@Transactional
+	@DisplayName("이슈에 열린 이슈 또는 닫힌 이슈가 표시되며, 기본은 열린 이슈이다.")
+	@Test
+	void 이슈는_기본적으로_열려있다() {
+		Issue issue = issueService.findIssueById(1L);
+		assertThat(issue.getStatus().isOpen()).isEqualTo(true);
+	}
+
+	@Transactional
+	@DisplayName("열린 이슈를 닫고 이를 검증한 후, 닫힌 이슈를 다시 열어서 이를 검증한다.")
+	@Test
+	void 열린_이슈를_닫고_닫힌_이슈를_열_수_있다() {
+		//open to closed
+		Issue issueBeforeClosed = issueService.findIssueById(1L);
+		issueBeforeClosed.changeStatusToClosed();
+		assertThat(issueService.findIssueById(1L).getStatus()).isEqualTo(Status.CLOSED);
+
+		//closed to open
+		Issue issueAfterClosed = issueService.findIssueById(1L);
+		issueAfterClosed.changeStatusToOpen();
+		assertThat(issueService.findIssueById(1L).getStatus()).isEqualTo(Status.OPEN);
+	}
+
+	@Transactional
+	@DisplayName("열린 이슈만 필터링하여 가져올 수 있다.")
+	@Test
+	void 열린_이슈만_보여줄_수_있다() {
+		List<IssueOverviewDto> OpenIssueOverviewDtoList = issueService.findAllOpenIssuesOverview();
+		assertThat(
+			OpenIssueOverviewDtoList.stream().map(IssueOverviewDto::getStatus)
+		).isNotEqualTo(Status.CLOSED);
+	}
+
+	@Transactional
+	@DisplayName("닫힌 이슈만 필터링하여 가져올 수 있다.")
+	@Test
+	void 닫힌_이슈만_보여줄_수_있다() {
+		List<IssueOverviewDto> ClosedIssueOverviewDtoList = issueService.findAllClosedIssuesOverview();
+		assertThat(
+			ClosedIssueOverviewDtoList.stream().map(IssueOverviewDto::getStatus)
+		).isNotEqualTo(Status.OPEN);
+	}
 }

--- a/BE/src/test/java/com/codesquad/issue04/web/controller/IssueControllerTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/web/controller/IssueControllerTest.java
@@ -2,17 +2,23 @@ package com.codesquad.issue04.web.controller;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Objects;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.reactive.server.WebTestClient;
 
+import com.codesquad.issue04.web.dto.response.error.ErrorResponseDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueOverviewResponseDtos;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient(timeout = "1500")
 public class IssueControllerTest {
 
 	@LocalServerPort
@@ -20,6 +26,9 @@ public class IssueControllerTest {
 
 	@Autowired
 	private TestRestTemplate restTemplate;
+
+	@Autowired
+	private WebTestClient webTestClient;
 
 	@Test
 	void 전체_요약_이슈를_요청해서_응답한다() {
@@ -34,5 +43,52 @@ public class IssueControllerTest {
 		// then
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(responseEntity.getBody()).isInstanceOf(IssueOverviewResponseDtos.class);
+	}
+
+	@Test
+	void 전체_열린_이슈만_선별해서_응답한다() {
+		String url = "http://localhost:" + port + "/api/v1/issues?status=open";
+		webTestClient.get()
+			.uri(url)
+			.exchange()
+			.expectStatus().isEqualTo(200)
+			.expectBodyList(IssueOverviewResponseDtos.class)
+			.consumeWith(response ->
+				assertThat(
+					Objects.requireNonNull(response.getResponseBody()).stream()
+						.allMatch(allData -> allData.getAllData().stream()
+							.allMatch(issue -> issue.getStatus().isOpen()))
+				).isEqualTo(true));
+	}
+
+	@Test
+	void 전체_닫힌_이슈만_선별해서_응답한다() {
+		String url = "http://localhost:" + port + "/api/v1/issues?status=closed";
+		webTestClient.get()
+			.uri(url)
+			.exchange()
+			.expectStatus().isEqualTo(200)
+			.expectBodyList(IssueOverviewResponseDtos.class)
+			.consumeWith(response ->
+				assertThat(
+					Objects.requireNonNull(response.getResponseBody()).stream()
+						.allMatch(allData -> allData.getAllData().stream()
+							.noneMatch(issue -> issue.getStatus().isOpen()))
+				).isEqualTo(true));
+	}
+
+	@Test
+	void 잘못된_인자가_들어오는_경우_오류를_반환한다() {
+		String url = "http://localhost:" + port + "/api/v1/issues?status=wrong";
+		ErrorResponseDto responseBody = webTestClient.get()
+			.uri(url)
+			.exchange()
+			.expectStatus()
+			.is4xxClientError()
+			.expectBody(ErrorResponseDto.class)
+			.returnResult()
+			.getResponseBody();
+		assert responseBody != null;
+		assertThat(responseBody.getMessage()).isEqualTo("wrong input but check");
 	}
 }


### PR DESCRIPTION
## 작업한 기능
* [x] 이슈의 열린 상태 또는 닫힌 상태의 표현
* [x] Issue Entity에 Status Value Object 추가(Enum 클래스)
* [x] Controller Mapping에 ```?status=open 또는 wrong```이 오도록 명시. 아니라면 all이라는 defaultValue 설정
* [x] 표준 응답객체를 설계하기 위하여 ResponseEntity를 활용하고 ErrorResponseDto라는 별도의 에러 반환 DTO 추가
* [x] Spring 5 WebClient를 활용한 ```IssueControllerTest``` 라는 이슈 컨트롤러 테스트 구현

## 참고 링크
* https://www.callicoder.com/spring-5-reactive-webclient-webtestclient-examples/
* https://inyl.github.io/programming/2018/03/10/springboot2_api.html
* https://engkimbs.tistory.com/808