### PR TITLE
이슈를 추가하고 존재하는 이슈의 제목을 수정하며 삭제할 수 있다.

### DIFF
--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -28,14 +28,13 @@ import com.codesquad.issue04.domain.milestone.NullMilestone;
 import com.codesquad.issue04.domain.user.NullUser;
 import com.codesquad.issue04.domain.user.RealUser;
 import com.codesquad.issue04.utils.BaseTimeEntity;
+import com.codesquad.issue04.web.dto.request.IssueUpdateRequestDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @ToString(exclude = {"comments", "assignees"})
 @Entity
@@ -120,5 +119,12 @@ public class Issue extends BaseTimeEntity {
 		newCommentList.add(comment);
 		this.comments = newCommentList;
 		return comment;
+	}
+
+	public Issue updateIssue(IssueUpdateRequestDto dto) {
+		if (! dto.getTitle().equals(this.title)) {
+			this.title = dto.getTitle();
+		}
+		return this;
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -1,11 +1,13 @@
 package com.codesquad.issue04.domain.issue;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -25,6 +27,7 @@ import com.codesquad.issue04.domain.milestone.Milestone;
 import com.codesquad.issue04.domain.milestone.NullMilestone;
 import com.codesquad.issue04.domain.user.NullUser;
 import com.codesquad.issue04.domain.user.RealUser;
+import com.codesquad.issue04.utils.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,17 +39,18 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString(exclude = {"comments", "assignees"})
 @Entity
-public class Issue {
+public class Issue extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false, unique = true)
 	private Long id;
 	private String title;
 
-	@OneToMany(fetch = FetchType.LAZY, mappedBy = "issue", cascade = CascadeType.REMOVE)
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "issue", cascade = CascadeType.ALL)
 	private List<Comment> comments;
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@JoinTable(
 		name = "label_has_issue",
 		joinColumns = @JoinColumn(name = "issue_id"),
@@ -54,7 +58,7 @@ public class Issue {
 	)
 	private Set<Label> labels;
 
-	@ManyToMany(fetch = FetchType.LAZY)
+	@ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinTable(
 		name = "assignee",
 		joinColumns = @JoinColumn(name = "issue_id"),
@@ -62,11 +66,11 @@ public class Issue {
 	)
 	private List<RealUser> assignees;
 
-	@ManyToOne
+	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(foreignKey = @ForeignKey(name = "milestone_id"))
 	private Milestone milestone;
 
-	@ManyToOne
+	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(foreignKey = @ForeignKey(name = "user_id"))
 	private RealUser user;
 
@@ -109,5 +113,12 @@ public class Issue {
 		Status closedStatus = Status.CLOSED;
 		this.status = closedStatus;
 		return closedStatus;
+	}
+
+	public Comment addComment(Comment comment) {
+		List<Comment> newCommentList = new ArrayList<>(this.comments);
+		newCommentList.add(comment);
+		this.comments = newCommentList;
+		return comment;
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/IssueRepository.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/IssueRepository.java
@@ -3,4 +3,6 @@ package com.codesquad.issue04.domain.issue;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IssueRepository extends JpaRepository<Issue, Long> {
+
+	Issue findTopByOrderByIdDesc();
 }

--- a/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
@@ -11,7 +11,8 @@ import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.domain.issue.IssueRepository;
 import com.codesquad.issue04.domain.user.NullUser;
 import com.codesquad.issue04.domain.user.UserRepository;
-import com.codesquad.issue04.web.dto.request.IssueCreateUpdateRequestDto;
+import com.codesquad.issue04.web.dto.request.IssueCreateRequestDto;
+import com.codesquad.issue04.web.dto.request.IssueUpdateRequestDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueDetailResponseDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueOverviewDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueOverviewResponseDtos;
@@ -79,7 +80,7 @@ public class IssueService {
 	}
 
 	@Transactional
-	public IssueDetailResponseDto createNewIssue(IssueCreateUpdateRequestDto dto) {
+	public IssueDetailResponseDto createNewIssue(IssueCreateRequestDto dto) {
 		Issue newIssue = Issue.builder()
 			.title(dto.getTitle())
 			.build();
@@ -101,5 +102,12 @@ public class IssueService {
 		return IssueDetailResponseDto.builder()
 			.issue(latestIssue)
 			.build();
+	}
+
+	@Transactional
+	public IssueDetailResponseDto updateExistingIssue(IssueUpdateRequestDto dto) {
+		Issue issue = findIssueById(dto.getId());
+		issue.updateIssue(dto);
+		return IssueDetailResponseDto.of(issue);
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
@@ -110,8 +110,11 @@ public class IssueService {
 	}
 
 	@Transactional
-	public ResponseDto updateExistingIssue(IssueUpdateRequestDto dto) {
+	public ResponseDto updateExistingIssue(IssueUpdateRequestDto dto, RealUser user) {
 		Issue issue = findIssueById(dto.getId());
+		if (! validateUserPermission(issue, user)) {
+			return createErrorResponseDto();
+		}
 		issue.updateIssue(dto);
 		return IssueDetailResponseDto.of(issue);
 	}

--- a/BE/src/main/java/com/codesquad/issue04/service/UserService.java
+++ b/BE/src/main/java/com/codesquad/issue04/service/UserService.java
@@ -45,4 +45,9 @@ public class UserService {
         return realUser.getAssignedIssues();
     }
 
+    public RealUser getUserByGitHubId(String githubId) {
+        return userRepository.findByGithubId(githubId)
+            .orElseThrow(() -> new IllegalArgumentException("no user found: " + githubId));
+    }
+
 }

--- a/BE/src/main/java/com/codesquad/issue04/utils/BaseTimeEntity.java
+++ b/BE/src/main/java/com/codesquad/issue04/utils/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.codesquad.issue04.utils;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	private LocalDateTime createdDate;
+
+	@LastModifiedDate
+	private LocalDateTime modifiedDate;
+
+}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueCreateRequestDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueCreateRequestDto.java
@@ -6,27 +6,27 @@ import java.util.List;
 import lombok.Getter;
 
 @Getter
-public class IssueCreateUpdateRequestDto {
+public class IssueCreateRequestDto {
 
 	private String title;
 	private String commentContent;
 	private String writerGitHubId;
 	private List<String> photoUrl;
 
-	public IssueCreateUpdateRequestDto(String title, String writerGitHubId) {
+	public IssueCreateRequestDto(String title, String writerGitHubId) {
 		this.title = title;
 		this.writerGitHubId = writerGitHubId;
 		this.photoUrl = Collections.emptyList();
 	}
 
-	public IssueCreateUpdateRequestDto(String title, String commentContent, String writerGitHubId) {
+	public IssueCreateRequestDto(String title, String commentContent, String writerGitHubId) {
 		this.title = title;
 		this.commentContent = commentContent;
 		this.writerGitHubId = writerGitHubId;
 		this.photoUrl = Collections.emptyList();
 	}
 
-	public IssueCreateUpdateRequestDto(String title, String commentContent, String writerGitHubId,
+	public IssueCreateRequestDto(String title, String commentContent, String writerGitHubId,
 		List<String> photoUrl) {
 		this.title = title;
 		this.commentContent = commentContent;

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueCreateUpdateRequestDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueCreateUpdateRequestDto.java
@@ -1,0 +1,36 @@
+package com.codesquad.issue04.web.dto.request;
+
+import java.util.Collections;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class IssueCreateUpdateRequestDto {
+
+	private String title;
+	private String commentContent;
+	private String writerGitHubId;
+	private List<String> photoUrl;
+
+	public IssueCreateUpdateRequestDto(String title, String writerGitHubId) {
+		this.title = title;
+		this.writerGitHubId = writerGitHubId;
+		this.photoUrl = Collections.emptyList();
+	}
+
+	public IssueCreateUpdateRequestDto(String title, String commentContent, String writerGitHubId) {
+		this.title = title;
+		this.commentContent = commentContent;
+		this.writerGitHubId = writerGitHubId;
+		this.photoUrl = Collections.emptyList();
+	}
+
+	public IssueCreateUpdateRequestDto(String title, String commentContent, String writerGitHubId,
+		List<String> photoUrl) {
+		this.title = title;
+		this.commentContent = commentContent;
+		this.writerGitHubId = writerGitHubId;
+		this.photoUrl = photoUrl;
+	}
+}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueDeleteRequestDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueDeleteRequestDto.java
@@ -1,0 +1,12 @@
+package com.codesquad.issue04.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class IssueDeleteRequestDto {
+	private Long id;
+
+	public IssueDeleteRequestDto(Long id) {
+		this.id = id;
+	}
+}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueUpdateRequestDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/request/IssueUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.codesquad.issue04.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class IssueUpdateRequestDto {
+
+	private Long id;
+	private String title;
+
+	public IssueUpdateRequestDto(Long id, String title) {
+		this.id = id;
+		this.title = title;
+	}
+}

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -24,6 +24,12 @@ spring:
     initialization-mode: always
     hikari:
       maximum-pool-size: 10
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      use-new-id-generator-mappings: false
   flyway:
     clean-on-validation-error: true
     url: jdbc:mysql://localhost:3306/issue04?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useLegacyDatetimeCode=false

--- a/BE/src/main/resources/db/migration/V1__CreateTable.sql
+++ b/BE/src/main/resources/db/migration/V1__CreateTable.sql
@@ -11,50 +11,52 @@ DROP TABLE IF EXISTS role;
 
 CREATE TABLE IF NOT EXISTS user
 (
-    id        INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    name      VARCHAR(45)                    NULL,
-    github_id VARCHAR(45)                    NULL,
-    image     VARCHAR(500)                   NULL,
-    role_key  VARCHAR(500)                   NULL
+    id        INT PRIMARY KEY AUTO_INCREMENT,
+    name      VARCHAR(45)  NULL,
+    github_id VARCHAR(45)  NULL,
+    image     VARCHAR(500) NULL,
+    role_key  VARCHAR(500) NULL
 );
 
 CREATE TABLE IF NOT EXISTS milestone
 (
-    id          INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    title       VARCHAR(45)                    NULL,
-    due_date    DATETIME                       NULL,
-    description VARCHAR(45)                    NULL
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    title       VARCHAR(45) NULL,
+    due_date    DATETIME    NULL,
+    description VARCHAR(45) NULL
 );
 
 CREATE TABLE IF NOT EXISTS issue
 (
-    id           INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    title        VARCHAR(45)                    NOT NULL,
-    status       VARCHAR(45)                    NOT NULL DEFAULT 'OPEN',
-    user_id      INT                            NOT NULL,
-    milestone_id INT                            NOT NULL,
+    id            INT PRIMARY KEY AUTO_INCREMENT,
+    title         VARCHAR(45) NOT NULL,
+    status        VARCHAR(45) DEFAULT 'OPEN',
+    created_date  DATETIME    NULL,
+    modified_date DATETIME    NULL,
+    user_id       INT         NULL,
+    milestone_id  INT         NULL,
     CONSTRAINT fk_issue_user FOREIGN KEY (user_id) REFERENCES user (id),
     CONSTRAINT fk_issue_milestone1 FOREIGN KEY (milestone_id) REFERENCES milestone (id)
 );
 
 CREATE TABLE IF NOT EXISTS comment
 (
-    id         INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    content    TEXT                           NULL,
-    created_at DATETIME                       NULL,
-    updated_at DATETIME                       NULL,
-    user_id    INT                            NOT NULL,
-    issue_id   INT                            NOT NULL,
+    id         INT PRIMARY KEY AUTO_INCREMENT,
+    content    TEXT     NULL,
+    created_at DATETIME NULL,
+    updated_at DATETIME NULL,
+    user_id    INT      NOT NULL,
+    issue_id   INT      NOT NULL,
     CONSTRAINT fk_comment_user1 FOREIGN KEY (user_id) REFERENCES user (id),
     CONSTRAINT fk_comment_issue1 FOREIGN KEY (issue_id) REFERENCES issue (id)
 );
 
 CREATE TABLE IF NOT EXISTS label
 (
-    id          INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    title       VARCHAR(45)                    NULL,
-    color       VARCHAR(45)                    NULL,
-    description VARCHAR(100)                   NULL
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    title       VARCHAR(45)  NULL,
+    color       VARCHAR(45)  NULL,
+    description VARCHAR(100) NULL
 );
 
 CREATE TABLE IF NOT EXISTS photo

--- a/BE/src/main/resources/db/migration/V2__InsertData.sql
+++ b/BE/src/main/resources/db/migration/V2__InsertData.sql
@@ -1,6 +1,12 @@
 INSERT INTO user (name, github_id, image, role_key)
 VALUES ('Jack', 'guswns1659',
-        'https://avatars3.githubusercontent.com/u/55608425?s=400&u=bb7394a04f87d003a70fe15c3d88cdc370171e5b&v=4', 'GUEST');
+        'https://avatars3.githubusercontent.com/u/55608425?s=400&u=bb7394a04f87d003a70fe15c3d88cdc370171e5b&v=4',
+        'GUEST');
+
+INSERT INTO user (name, github_id, image, role_key)
+VALUES ('Sigrid Jin', 'jypthemiracle',
+        'https://avatars3.githubusercontent.com/u/55608425?s=400&u=bb7394a04f87d003a70fe15c3d88cdc370171e5b&v=4',
+        'GUEST');
 
 INSERT INTO milestone (title, due_date, description)
 VALUES ('1차 배포', '2020-06-28', '1차 배포');

--- a/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
@@ -2,6 +2,7 @@ package com.codesquad.issue04.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.domain.user.RealUser;
-import com.codesquad.issue04.domain.issue.Status;
+import com.codesquad.issue04.web.dto.request.IssueCreateUpdateRequestDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueDetailResponseDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueOverviewDto;
 
@@ -85,5 +86,25 @@ public class IssueServiceTest {
 
         assertThat(issue.getAssignees().get(0)).isInstanceOf(RealUser.class);
         assertThat(issue.getAssignees().get(0).getGithubId()).isEqualTo("guswns1659");
+    }
+
+    @Transactional
+    @DisplayName("새로운 이슈가 추가된다.")
+    @CsvSource({"test title, test comment, test_id"})
+    @ParameterizedTest
+    void 새로운_이슈_하나가_추가된다(String title, String comment, String githubId) {
+        List<String> photoUrls = Arrays.asList("naver.com", "yahoo.com", "google.com");
+        IssueCreateUpdateRequestDto dto = new IssueCreateUpdateRequestDto(title, comment, githubId, photoUrls);
+        issueService.createNewIssue(dto);
+
+        assertThat(issueService.findLatestIssue()).isInstanceOf(IssueDetailResponseDto.class);
+        assertThat(issueService.findLatestIssue().getTitle()).isEqualTo(title);
+    }
+
+    @Transactional
+    @DisplayName("기존의 이슈가 업데이트된다.")
+    @Test
+    void 기존의_이슈가_업데이트된다() {
+        //
     }
 }

--- a/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
@@ -1,6 +1,7 @@
 package com.codesquad.issue04.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,96 +16,104 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.domain.user.RealUser;
-import com.codesquad.issue04.web.dto.request.IssueCreateUpdateRequestDto;
+import com.codesquad.issue04.web.dto.request.IssueCreateRequestDto;
+import com.codesquad.issue04.web.dto.request.IssueUpdateRequestDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueDetailResponseDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueOverviewDto;
 
 @SpringBootTest
 public class IssueServiceTest {
 
-    @Autowired
-    private IssueService issueService;
+	@Autowired
+	private IssueService issueService;
 
-    @Transactional
-    @DisplayName("이슈 하나를 테스트로 가져온다.")
-    @Test
-    void 이슈_하나를_가져온다() {
+	@Transactional
+	@DisplayName("이슈 하나를 테스트로 가져온다.")
+	@Test
+	void 이슈_하나를_가져온다() {
 
-        Issue issueById = issueService.findIssueById(1L);
-        assertThat(issueById).isInstanceOf(Issue.class);
-        assertThat(issueById.getTitle()).isEqualTo("SQL 작성");
-        assertThat(issueById.getComments().get(0).getContent()).isEqualTo("아하하 어렵네요.");
-        assertThat(issueById.getComments().get(0).getPhotos().size()).isGreaterThan(0);
-    }
+		Issue issueById = issueService.findIssueById(1L);
+		assertThat(issueById).isInstanceOf(Issue.class);
+		assertThat(issueById.getTitle()).isEqualTo("SQL 작성");
+		assertThat(issueById.getComments().get(0).getContent()).isEqualTo("아하하 어렵네요.");
+		assertThat(issueById.getComments().get(0).getPhotos().size()).isGreaterThan(0);
+	}
 
-    @Transactional
-    @DisplayName("댓글 별로 이모지가 별도로 가져와진다. 1번째 댓글은 1개의 이모지를 지니고, 2번째 댓글은 2개의 이모지를 지닌다. 유의할 점은 commentId가 아니라 commentIndex라는 점이다.")
-    @CsvSource({"1, 0, 1", "1, 1, 2"})
-    @ParameterizedTest
-    void 댓글_별로_이모지가_불러진다(Long issueId, int commentIndex, int expectedSize) {
-        assertThat(issueService.findIssueById(issueId).getComments().get(commentIndex).getEmojis().size())
-            .isEqualTo(expectedSize);
-    }
+	@Transactional
+	@DisplayName("댓글 별로 이모지가 별도로 가져와진다. 1번째 댓글은 1개의 이모지를 지니고, 2번째 댓글은 2개의 이모지를 지닌다. 유의할 점은 commentId가 아니라 commentIndex라는 점이다.")
+	@CsvSource({"1, 0, 1", "1, 1, 2"})
+	@ParameterizedTest
+	void 댓글_별로_이모지가_불러진다(Long issueId, int commentIndex, int expectedSize) {
+		assertThat(issueService.findIssueById(issueId).getComments().get(commentIndex).getEmojis().size())
+			.isEqualTo(expectedSize);
+	}
 
-    @Transactional
-    @DisplayName("이슈 전체를 가져온다.")
-    @CsvSource({"0, SQL 작성", "1, 스키마 작성"})
-    @ParameterizedTest
-    void 이슈_전체를_가져온다(int index, String expectedTitle) {
+	@Transactional
+	@DisplayName("이슈 전체를 가져온다.")
+	@CsvSource({"0, SQL 작성", "1, 스키마 작성"})
+	@ParameterizedTest
+	void 이슈_전체를_가져온다(int index, String expectedTitle) {
 
-        List<Issue> issues = issueService.findAllIssues();
-        assertThat(issues.get(index).getTitle()).isEqualTo(expectedTitle);
-    }
+		List<Issue> issues = issueService.findAllIssues();
+		assertThat(issues.get(index).getTitle()).isEqualTo(expectedTitle);
+	}
 
-    @Transactional
-    @DisplayName("이슈 전체를 가져와 각 이슈의 요약을 보여준다.")
-    @Test
-    void 전체_이슈의_요약을_생성한다() {
+	@Transactional
+	@DisplayName("이슈 전체를 가져와 각 이슈의 요약을 보여준다.")
+	@Test
+	void 전체_이슈의_요약을_생성한다() {
 
-        List<IssueOverviewDto> issueOverviewDtos = issueService.findAllIssuesOverview();
-        assertThat(issueOverviewDtos.get(0)).isInstanceOf(IssueOverviewDto.class);
-    }
+		List<IssueOverviewDto> issueOverviewDtos = issueService.findAllIssuesOverview();
+		assertThat(issueOverviewDtos.get(0)).isInstanceOf(IssueOverviewDto.class);
+	}
 
-    @Transactional
-    @DisplayName("각 이슈의 디테일을 보여준다.")
-    @CsvSource({"1, SQL 작성", "2, 스키마 작성"})
-    @ParameterizedTest
-    void 각_이슈의_디테일을_보여준다(Long id, String title) {
+	@Transactional
+	@DisplayName("각 이슈의 디테일을 보여준다.")
+	@CsvSource({"1, SQL 작성", "2, 스키마 작성"})
+	@ParameterizedTest
+	void 각_이슈의_디테일을_보여준다(Long id, String title) {
 
-        IssueDetailResponseDto issueDetailResponseDto = issueService.findIssueDetailById(id);
-        assertThat(issueDetailResponseDto.getId()).isEqualTo(id);
-        assertThat(issueDetailResponseDto.getTitle()).isEqualTo(title);
-        assertThat(issueDetailResponseDto.getRealUser().getOwnedIssues().size()).isGreaterThan(0);
-    }
+		IssueDetailResponseDto issueDetailResponseDto = issueService.findIssueDetailById(id);
+		assertThat(issueDetailResponseDto.getId()).isEqualTo(id);
+		assertThat(issueDetailResponseDto.getTitle()).isEqualTo(title);
+		assertThat(issueDetailResponseDto.getRealUser().getOwnedIssues().size()).isGreaterThan(0);
+	}
 
-    @Transactional
-    @DisplayName("이슈가 할당된 유저를 가져온다.")
-    @Test
-    void 이슈가_할당된_유저를_가져온다() {
-        Long issueId = 1L;
-        Issue issue = issueService.findIssueById(issueId);
+	@Transactional
+	@DisplayName("이슈가 할당된 유저를 가져온다.")
+	@Test
+	void 이슈가_할당된_유저를_가져온다() {
+		Long issueId = 1L;
+		Issue issue = issueService.findIssueById(issueId);
 
-        assertThat(issue.getAssignees().get(0)).isInstanceOf(RealUser.class);
-        assertThat(issue.getAssignees().get(0).getGithubId()).isEqualTo("guswns1659");
-    }
+		assertThat(issue.getAssignees().get(0)).isInstanceOf(RealUser.class);
+		assertThat(issue.getAssignees().get(0).getGithubId()).isEqualTo("guswns1659");
+	}
 
-    @Transactional
-    @DisplayName("새로운 이슈가 추가된다.")
-    @CsvSource({"test title, test comment, test_id"})
-    @ParameterizedTest
-    void 새로운_이슈_하나가_추가된다(String title, String comment, String githubId) {
-        List<String> photoUrls = Arrays.asList("naver.com", "yahoo.com", "google.com");
-        IssueCreateUpdateRequestDto dto = new IssueCreateUpdateRequestDto(title, comment, githubId, photoUrls);
-        issueService.createNewIssue(dto);
+	@Transactional
+	@DisplayName("새로운 이슈가 추가된다.")
+	@CsvSource({"test title, test comment, test_id"})
+	@ParameterizedTest
+	void 새로운_이슈_하나가_추가된다(String title, String comment, String githubId) {
+		List<String> photoUrls = Arrays.asList("codesquad.kr", "edu.nextstep.camp", "woowacourse.github.io");
+		IssueCreateRequestDto dto = new IssueCreateRequestDto(title, comment, githubId, photoUrls);
+		issueService.createNewIssue(dto);
 
-        assertThat(issueService.findLatestIssue()).isInstanceOf(IssueDetailResponseDto.class);
-        assertThat(issueService.findLatestIssue().getTitle()).isEqualTo(title);
-    }
+		assertThat(issueService.findLatestIssue()).isInstanceOf(IssueDetailResponseDto.class);
+		assertThat(issueService.findLatestIssue().getTitle()).isEqualTo(title);
+	}
 
-    @Transactional
-    @DisplayName("기존의 이슈가 업데이트된다.")
-    @Test
-    void 기존의_이슈가_업데이트된다() {
-        //
-    }
+	@Transactional
+	@DisplayName("기존의 이슈가 업데이트된다.")
+	@CsvSource({"1, updated title"})
+	@ParameterizedTest
+	void 기존의_이슈의_제목이_업데이트된다(Long id, String title) {
+		IssueUpdateRequestDto dto = new IssueUpdateRequestDto(id, title);
+		IssueDetailResponseDto detailResponseDto = issueService.updateExistingIssue(dto);
+
+		assertAll(
+			() -> assertThat(detailResponseDto.getTitle()).isEqualTo(title),
+			() -> assertThat(issueService.findIssueById(1L).getTitle()).isEqualTo(title)
+		);
+	}
 }

--- a/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
@@ -19,6 +19,7 @@ import com.codesquad.issue04.domain.user.RealUser;
 import com.codesquad.issue04.web.dto.request.IssueCreateRequestDto;
 import com.codesquad.issue04.web.dto.request.IssueDeleteRequestDto;
 import com.codesquad.issue04.web.dto.request.IssueUpdateRequestDto;
+import com.codesquad.issue04.web.dto.response.error.ErrorResponseDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueDetailResponseDto;
 import com.codesquad.issue04.web.dto.response.issue.IssueOverviewDto;
 
@@ -109,16 +110,20 @@ public class IssueServiceTest {
 
 	@Transactional
 	@DisplayName("기존의 이슈가 업데이트된다.")
-	@CsvSource({"1, updated title"})
+	@CsvSource({"1, updated title, guswns1659, jypthemiracle"})
 	@ParameterizedTest
-	void 기존의_이슈의_제목이_업데이트된다(Long id, String title) {
+	void 기존의_이슈의_제목이_업데이트된다(Long id, String title, String githubId, String notAuthorUserId) {
 		IssueUpdateRequestDto dto = new IssueUpdateRequestDto(id, title);
-		IssueDetailResponseDto detailResponseDto = (IssueDetailResponseDto) issueService.updateExistingIssue(dto);
+		RealUser user = userService.getUserByGitHubId(githubId);
+		IssueDetailResponseDto detailResponseDto = (IssueDetailResponseDto) issueService.updateExistingIssue(dto, user);
 
 		assertAll(
 			() -> assertThat(detailResponseDto.getTitle()).isEqualTo(title),
 			() -> assertThat(issueService.findIssueById(1L).getTitle()).isEqualTo(title)
 		);
+
+		RealUser notAuthorUser = userService.getUserByGitHubId(notAuthorUserId);
+		assertThat(issueService.updateExistingIssue(dto, notAuthorUser)).isInstanceOf(ErrorResponseDto.class);
 	}
 
 	@Transactional


### PR DESCRIPTION
## 구현한 사항
* [x] 새로운 이슈를 추가할 수 있다.
* [x] 데이터베이스 상에 저장된 이슈의 제목을 수정할 수 있다.
* [x] 데이터베이스 상에 저장된 이슈를 삭제할 수 있다.
* [x] 데이터베이스 상에 저장된 이슈의 제목을 수정할 때 작성자 여부를 확인한다.
* [x] 데이터베이스 상에 저장된 이슈를 삭제할 때 작성자 여부를 확인한다.

## 알게된 점
* CascadeType.ALL과 다른 옵션의 차이점
* 내부 객체의 저장 순서를 주의해서 보자는 교훈

## 추가 작업 사항
* 데이터베이스 상에 저장된 이슈의 라벨과 마일스톤을 수정할 수 있다.
* 해당 기능은 라벨과 마일스톤을 추가하는 기능을 구현한 후에 작업하는 것이 논리적으로 자연스러울 것 같아 이번에는 작업하지 않았다.