### PR TITLE
이슈에 마일스톤과 라벨을 추가하고 삭제할 수 있다.

### DIFF
--- a/BE/src/main/java/com/codesquad/issue04/config/WebConfig.java
+++ b/BE/src/main/java/com/codesquad/issue04/config/WebConfig.java
@@ -1,14 +1,8 @@
 package com.codesquad.issue04.config;
 
-import java.util.List;
-
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import com.codesquad.issue04.web.oauth.LoginInterceptor;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -26,15 +20,15 @@ public class WebConfig implements WebMvcConfigurer {
             .maxAge(MAX_AGE_SECS);
     }
 
-    @Bean
-    public LoginInterceptor loginInterceptor() {
-        return new LoginInterceptor();
-    }
-
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(loginInterceptor())
-            .addPathPatterns("/**")
-            .excludePathPatterns(EXCLUDE_PATHS);
-    }
+    // @Bean
+    // public LoginInterceptor loginInterceptor() {
+    //     return new LoginInterceptor();
+    // }
+    //
+    // @Override
+    // public void addInterceptors(InterceptorRegistry registry) {
+    //     registry.addInterceptor(loginInterceptor())
+    //         .addPathPatterns("/**")
+    //         .excludePathPatterns(EXCLUDE_PATHS);
+    // }
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -158,4 +158,9 @@ public class Issue extends BaseTimeEntity {
 			throw new IllegalArgumentException("not matched issue");
 		}
 	}
+
+	public Milestone updateMilestone(Milestone milestone) {
+		this.milestone = milestone;
+		return milestone;
+	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -163,4 +163,11 @@ public class Issue extends BaseTimeEntity {
 		this.milestone = milestone;
 		return milestone;
 	}
+
+	public Milestone deleteMilestone(Long milestoneId) {
+		if (milestone.getId().equals(milestoneId)) {
+			this.milestone = NullMilestone.of();
+		}
+		return this.milestone;
+	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -23,6 +23,7 @@ import com.codesquad.issue04.domain.issue.vo.Comment;
 import com.codesquad.issue04.domain.issue.vo.Status;
 import com.codesquad.issue04.domain.issue.vo.firstcollection.Comments;
 import com.codesquad.issue04.domain.issue.vo.firstcollection.Labels;
+import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
 import com.codesquad.issue04.domain.milestone.NullMilestone;
 import com.codesquad.issue04.domain.user.NullUser;
@@ -114,14 +115,14 @@ public class Issue extends BaseTimeEntity {
 		return this.getAssignees().size() > 0;
 	}
 
-	public Comment addComment(Comment comment) {
+	public Comment addComment(final Comment comment) {
 		List<Comment> newCommentList = this.comments.returnCommentsCreatingNewList();
 		newCommentList.add(comment);
 		this.comments = Comments.ofComments(newCommentList);
 		return comment;
 	}
 
-	public Issue updateIssue(IssueUpdateRequestDto dto) {
+	public Issue updateIssue(final IssueUpdateRequestDto dto) {
 		if (! dto.getTitle().equals(this.title)) {
 			this.title = dto.getTitle();
 		}
@@ -132,7 +133,7 @@ public class Issue extends BaseTimeEntity {
 		return this.comments.getOverview();
 	}
 
-	public Comment getCommentByIndex(int commentIndex) {
+	public Comment getCommentByIndex(final int commentIndex) {
 		return this.comments.getCommentByIndex(commentIndex);
 	}
 
@@ -140,34 +141,46 @@ public class Issue extends BaseTimeEntity {
 		return this.comments.getLatestComment();
 	}
 
-	public Comment findCommentById(Long commentId) {
+	public Comment findCommentById(final Long commentId) {
 		return this.comments.findCommentById(commentId);
 	}
 
-	public Comment deleteCommentById(Long commentId) {
+	public Comment deleteCommentById(final Long commentId) {
 		return this.comments.deleteCommentById(commentId);
 	}
 
-	public Comment modifyCommentByDto(CommentUpdateRequestDto dto) {
+	public Comment modifyCommentByDto(final CommentUpdateRequestDto dto) {
 		doesMatchId(dto);
 		return this.comments.modifyCommentByDto(dto);
 	}
 
-	private void doesMatchId(CommentUpdateRequestDto dto) {
+	private void doesMatchId(final CommentUpdateRequestDto dto) {
 		if (! this.id.equals(dto.getIssueId())) {
 			throw new IllegalArgumentException("not matched issue");
 		}
 	}
 
-	public Milestone updateMilestone(Milestone milestone) {
+	public Milestone updateMilestone(final Milestone milestone) {
 		this.milestone = milestone;
 		return milestone;
 	}
 
-	public Milestone deleteMilestone(Long milestoneId) {
+	public Milestone deleteMilestone(final Long milestoneId) {
 		if (milestone.getId().equals(milestoneId)) {
 			this.milestone = NullMilestone.of();
 		}
 		return this.milestone;
+	}
+
+	public boolean checkLabelsContainsByLabelId(final Long labelId) {
+		return labels.checkLabelsContainsByLabelId(labelId);
+	}
+
+	public Label addNewLabel(final Label label) {
+		return labels.addNewLabel(label);
+	}
+
+	public Label deleteExistingLabel(final Label label) {
+		return labels.deleteExistingLabel(label);
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/Comment.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/Comment.java
@@ -80,7 +80,7 @@ public class Comment implements Serializable {
 		this.issue = issue;
 	}
 
-	public static Comment ofDto(CommentCreateRequestDto dto, RealUser user, Issue issue) {
+	public static Comment ofDto(final CommentCreateRequestDto dto, final RealUser user, final Issue issue) {
 		return new Comment(dto.getContent(), dto.getEmojis(), dto.getPhotos(), user, issue);
 	}
 
@@ -103,14 +103,14 @@ public class Comment implements Serializable {
 		return this.user.getId();
 	}
 
-	public Comment updateComment(CommentUpdateRequestDto dto) {
+	public Comment updateComment(final CommentUpdateRequestDto dto) {
 		this.content = dto.getContent();
 		this.photos = dto.getMockPhotos();
 		this.emojis = dto.getMockEmojis();
 		return this;
 	}
 
-	public boolean doesMatchId(Long commentId) {
+	public boolean doesMatchId(final Long commentId) {
 		return this.id.equals(commentId);
 	}
 

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/Photo.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/Photo.java
@@ -17,7 +17,7 @@ public class Photo {
 		this.url = url;
 	}
 
-	public static Photo ofUrl(String url) {
+	public static Photo ofUrl(final String url) {
 		return new Photo(url);
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/firstcollection/Labels.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/firstcollection/Labels.java
@@ -43,4 +43,23 @@ public class Labels {
 			.map(Label::getTitle)
 			.collect(Collectors.toSet());
 	}
+
+	public boolean checkLabelsContainsByLabelId(final Long labelId) {
+		return labels.stream()
+			.anyMatch(label -> label.getId().equals(labelId));
+	}
+
+	public Label addNewLabel(final Label label) {
+		Set<Label> labelSet = new HashSet<>(this.labels);
+		labelSet.add(label);
+		this.labels = labelSet;
+		return label;
+	}
+
+	public Label deleteExistingLabel(final Label label) {
+		Set<Label> labelSet = new HashSet<>(this.labels);
+		labelSet.remove(label);
+		this.labels = labelSet;
+		return label;
+	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/domain/label/Label.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/label/Label.java
@@ -45,7 +45,7 @@ public class Label {
 	)
 	private Set<Issue> issues;
 
-	public Label updateLabel(LabelUpdateRequestDto dto) {
+	public Label updateLabel(final LabelUpdateRequestDto dto) {
 		this.title = dto.getTitle();
 		this.color = dto.getColor();
 		this.description = dto.getDescription();

--- a/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
@@ -42,7 +42,7 @@ public class Milestone implements AbstractMilestone {
 		return false;
 	}
 
-	public Milestone updateMilestone(MilestoneUpdateRequestDto dto) {
+	public Milestone updateMilestone(final MilestoneUpdateRequestDto dto) {
 		this.title = dto.getTitle();
 		this.dueDate = dto.getDueDate();
 		this.description = dto.getDescription();

--- a/BE/src/main/java/com/codesquad/issue04/domain/user/RealUser.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/user/RealUser.java
@@ -7,8 +7,6 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -69,7 +67,7 @@ public class RealUser implements Serializable, AbstractUser {
             .build();
     }
 
-    public RealUser update(String name, String picture) {
+    public RealUser update(final String name, final String picture) {
         this.name = name;
         this.image = picture;
         return this;

--- a/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issue04/service/IssueService.java
@@ -208,10 +208,15 @@ public class IssueService {
 		return milestoneRepository.findById(milestoneId).orElseGet(NullMilestone::of);
 	}
 
-	public Milestone changeMilestone(Long issueId, Long milestoneId) {
+	public Milestone updateMilestone(Long issueId, Long milestoneId) {
 		Issue issue = findIssueById(issueId);
 		Milestone milestone = getMilestoneById(milestoneId);
 		issue.updateMilestone(milestone);
 		return milestone;
+	}
+
+	public Milestone deleteMilestone(Long issueId, Long milestoneId) {
+		Issue issue = findIssueById(issueId);
+		return issue.deleteMilestone(milestoneId);
 	}
 }

--- a/BE/src/main/java/com/codesquad/issue04/service/LabelService.java
+++ b/BE/src/main/java/com/codesquad/issue04/service/LabelService.java
@@ -22,7 +22,7 @@ public class LabelService {
 
 	private final LabelRepository labelRepository;
 
-	protected Label findLabelById(Long labelId) {
+	protected Label findLabelById(final Long labelId) {
 		return labelRepository.findById(labelId)
 			.orElseThrow(() -> new IllegalArgumentException("label not found id: " + labelId));
 	}
@@ -49,28 +49,29 @@ public class LabelService {
 	}
 
 	@Transactional
-	public LabelDetailResponseDto findLatestIssue() {
+	public LabelDetailResponseDto findLatestLabel() {
 		Label latestLabel = labelRepository.findTopByOrderByIdDesc();
 		return LabelDetailResponseDto.of(latestLabel);
 	}
 
 	@Transactional
-	public Label createNewLabel(LabelCreateRequestDto dto) {
+	public Label createNewLabel(final LabelCreateRequestDto dto) {
 		Label savedLabel = Label.builder()
 			.title(dto.getTitle())
 			.color(dto.getColor())
 			.description(dto.getDescription())
 			.build();
+		labelRepository.save(savedLabel);
 		return savedLabel;
 	}
 
-	public Label updateExistingLabel(LabelUpdateRequestDto dto) {
+	public Label updateExistingLabel(final LabelUpdateRequestDto dto) {
 		Label updatedLabel = findLabelById(dto.getId());
 		updatedLabel.updateLabel(dto);
 		return updatedLabel;
 	}
 
-	public Label deleteExistingLabel(LabelDeleteRequestDto dto) {
+	public Label deleteExistingLabel(final LabelDeleteRequestDto dto) {
 		Label deletedLabel = findLabelById(dto.getId());
 		labelRepository.delete(deletedLabel);
 		return deletedLabel;

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/request/CommentDeleteRequestDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/request/CommentDeleteRequestDto.java
@@ -1,0 +1,16 @@
+package com.codesquad.issue04.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CommentDeleteRequestDto extends CommentRequestDto {
+	private Long issueId;
+	private Long commentId;
+	private String userGithubId;
+
+	public CommentDeleteRequestDto(Long issueId, Long commentId, String userGithubId) {
+		this.issueId = issueId;
+		this.commentId = commentId;
+		this.userGithubId = userGithubId;
+	}
+}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/request/CommentRequestDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/request/CommentRequestDto.java
@@ -1,0 +1,10 @@
+package com.codesquad.issue04.web.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public abstract class CommentRequestDto {
+	private Long issueId;
+	private Long commentId;
+	private String userGithubId;
+}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/request/CommentUpdateRequestDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/request/CommentUpdateRequestDto.java
@@ -7,17 +7,19 @@ import com.codesquad.issue04.domain.issue.vo.Photo;
 import lombok.Getter;
 
 @Getter
-public class CommentUpdateRequestDto {
+public class CommentUpdateRequestDto extends CommentRequestDto {
 	private Long issueId;
 	private Long commentId;
+	private String userGithubId;
 	private String content;
 	private List<Photo> mockPhotos;
 	private List<Emoji> mockEmojis;
 
-	public CommentUpdateRequestDto(Long issueId, Long commentId, String content,
+	public CommentUpdateRequestDto(Long issueId, Long commentId, String userGithubId, String content,
 		List<Photo> mockPhotos, List<Emoji> mockEmojis) {
 		this.issueId = issueId;
 		this.commentId = commentId;
+		this.userGithubId = userGithubId;
 		this.content = content;
 		this.mockPhotos = mockPhotos;
 		this.mockEmojis = mockEmojis;

--- a/BE/src/main/resources/db/migration/V2__InsertData.sql
+++ b/BE/src/main/resources/db/migration/V2__InsertData.sql
@@ -8,6 +8,12 @@ VALUES ('Sigrid Jin', 'jypthemiracle',
 INSERT INTO milestone (title, due_date, description)
 VALUES ('1차 배포', '2020-06-28', '1차 배포');
 
+INSERT INTO milestone (title, due_date, description)
+VALUES ('2차 배포', '2020-07-01', '2차 배포');
+
+INSERT INTO milestone (title, due_date, description)
+VALUES ('3차 배포', '2020-07-02', '3차 배포');
+
 INSERT INTO issue (title, user_id, milestone_id)
 VALUES ('SQL 작성', 1, 1);
 

--- a/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
@@ -21,6 +21,7 @@ import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.domain.issue.vo.Emoji;
 import com.codesquad.issue04.domain.issue.vo.Photo;
 import com.codesquad.issue04.domain.milestone.Milestone;
+import com.codesquad.issue04.domain.milestone.NullMilestone;
 import com.codesquad.issue04.domain.user.RealUser;
 import com.codesquad.issue04.web.dto.request.CommentCreateRequestDto;
 import com.codesquad.issue04.web.dto.request.CommentDeleteRequestDto;
@@ -243,23 +244,28 @@ public class IssueServiceTest {
 	@CsvSource({"1, 2"})
 	@ParameterizedTest
 	void 이슈에_새로운_마일스톤을_추가한다(Long issueId, Long milestoneId) {
-		Milestone milestone = issueService.changeMilestone(issueId, milestoneId);
+		Milestone milestone = issueService.updateMilestone(issueId, milestoneId);
 		assertThat(issueService.findIssueById(issueId).getMilestone()).isEqualTo(milestone);
 	}
 
 	@Transactional
 	@DisplayName("마일스톤을 삭제한다.")
-	@CsvSource({"1"})
+	@CsvSource({"1, 2"})
 	@ParameterizedTest
-	void 이슈의_마일스톤을_삭제한다(Long milestoneId) {
-		//
+	void 이슈의_마일스톤을_삭제한다(Long issueId, Long milestoneId) {
+		Milestone milestone = issueService.updateMilestone(issueId, milestoneId);
+		assertThat(issueService.findIssueById(issueId).getMilestone()).isEqualTo(milestone);
+		issueService.deleteMilestone(issueId, milestoneId);
+		assertThat(issueService.findIssueById(issueId).getMilestone()).isInstanceOf(NullMilestone.class);
 	}
 
 	@Transactional
 	@DisplayName("이미 마일스톤이 부여된 이슈에 다른 마일스톤으로 변경한다.")
-	@CsvSource({"1, 3"})
+	@CsvSource({"1, 2, 3"})
 	@ParameterizedTest
-	void 이슈의_마일스톤을_변경한다(Long milestoneId) {
-		//
+	void 이슈의_마일스톤을_변경한다(Long issueId, Long beforeMilestoneId, Long afterMilestoneId) {
+		issueService.updateMilestone(issueId, beforeMilestoneId);
+		Milestone modifiedMilestone = issueService.updateMilestone(issueId, afterMilestoneId);
+		assertThat(issueService.findIssueById(issueId).getMilestone()).isEqualTo(modifiedMilestone);
 	}
 }

--- a/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/IssueServiceTest.java
@@ -268,4 +268,22 @@ public class IssueServiceTest {
 		Milestone modifiedMilestone = issueService.updateMilestone(issueId, afterMilestoneId);
 		assertThat(issueService.findIssueById(issueId).getMilestone()).isEqualTo(modifiedMilestone);
 	}
+
+	@Transactional
+	@DisplayName("새로운 라벨을 추가한다.")
+	@CsvSource({"1, 1"})
+	@ParameterizedTest
+	void 이슈의_라벨에_하나_추가한다(Long issueId, Long labelId) {
+		issueService.addNewLabel(issueId, labelId);
+		assertThat(issueService.findIssueById(issueId).checkLabelsContainsByLabelId(labelId)).isEqualTo(true);
+	}
+
+	@Transactional
+	@DisplayName("라벨을 삭제한다.")
+	@CsvSource({"1, 1"})
+	@ParameterizedTest
+	void 이슈의_라벨에_하나_삭제한다(Long issueId, Long labelId) {
+		issueService.deleteLabel(issueId, labelId);
+		assertThat(issueService.findIssueById(issueId).checkLabelsContainsByLabelId(labelId)).isEqualTo(false);
+	}
 }

--- a/BE/src/test/java/com/codesquad/issue04/service/LabelServiceTest.java
+++ b/BE/src/test/java/com/codesquad/issue04/service/LabelServiceTest.java
@@ -59,7 +59,7 @@ public class LabelServiceTest {
 	void 라벨_하나가_추가된다(String title, String color, String description) {
 		LabelCreateRequestDto dto = new LabelCreateRequestDto(title, color, description);
 		labelService.createNewLabel(dto);
-		LabelDetailResponseDto savedLabelDto = labelService.findLatestIssue();
+		LabelDetailResponseDto savedLabelDto = labelService.findLatestLabel();
 		assertAll(
 			() -> assertThat(savedLabelDto.getTitle()).isEqualTo(title),
 			() -> assertThat(savedLabelDto.getColor()).isEqualTo(color),


### PR DESCRIPTION
## 구현한 기능
* [x] 이슈에 마일스톤을 추가할 수 있다.
* [x] 이슈에 마일스톤을 삭제할 수 있다.
* [x] 이슈에 라벨을 추가할 수 있다.
* [x] 이슈에 라벨을 삭제할 수 있다.
* [x] 이슈에 댓글 및 마일스톤을 추가하는 부분에서 테스트 코드에 비즈니스 로직이 있었던 코드를 IssueService로 이동했다.
* [x] 이슈 및 댓글을 삭제할 때 DTO에 있는 사용자 깃헙 아이디를 통해 작성자 여부를 검증한다.
* [x] final keyword를 다른 메소드로부터 인자값을 받는 각각의 파라미터에 붙여줌으로써 불변성을 강화한다.

## 참고할 사항
* [x] 테스트 중 UserControllerTest에서 "작성자 전체를 응답한다" 메소드 중 34번 째 줄의 NPE 에러를 해결하지 못했다.