### PR TITLE
마일스톤 삭제 기능을 정상적으로 구현하도록 수정한다.

### DIFF
--- a/BE/src/main/java/com/codesquad/issue04/config/SwaggerConfig.java
+++ b/BE/src/main/java/com/codesquad/issue04/config/SwaggerConfig.java
@@ -14,6 +14,7 @@ public class SwaggerConfig {
 	@Bean
 	public Docket api() {
 		return new Docket(DocumentationType.SWAGGER_2)
+			.host("15.165.66.150")
 			.select()
 			.build();
 	}

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/Issue.java
@@ -9,6 +9,7 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -32,9 +33,11 @@ import com.codesquad.issue04.web.dto.request.issue.IssueUpdateRequestDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @ToString(exclude = {"comments", "assignees"})
 @Entity
@@ -55,8 +58,8 @@ public class Issue extends BaseTimeEntity {
 	@Embedded
 	private Assignees assignees;
 
-	@ManyToOne(cascade = CascadeType.PERSIST)
-	@JoinColumn(foreignKey = @ForeignKey(name = "milestone_id"))
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@JoinColumn(name = "milestone_id", nullable = true)
 	private Milestone milestone;
 
 	@ManyToOne(cascade = CascadeType.PERSIST)

--- a/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/firstcollection/Assignees.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/issue/vo/firstcollection/Assignees.java
@@ -22,7 +22,6 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Assignees {
 
-	@JsonIgnore
 	@OneToMany(orphanRemoval = true, cascade = CascadeType.ALL)
 	@LazyCollection(LazyCollectionOption.FALSE)
 	@JoinTable(

--- a/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
@@ -5,11 +5,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.web.dto.request.milestone.MilestoneCreateRequestDto;
@@ -20,6 +27,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
@@ -38,7 +46,13 @@ public class Milestone implements AbstractMilestone {
 	private String description;
 
 	@JsonIgnore
-	@OneToMany
+	@OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+	@LazyCollection(LazyCollectionOption.FALSE)
+	@JoinTable(
+		name = "milestone_has_issue",
+		joinColumns = @JoinColumn(name = "milestone_id"),
+		inverseJoinColumns = @JoinColumn(name = "issue_id")
+	)
 	private List<Issue> issues = new ArrayList<>();
 
 	@Override
@@ -51,6 +65,10 @@ public class Milestone implements AbstractMilestone {
 		this.dueDate = dto.getDueDate();
 		this.description = dto.getDescription();
 		return this;
+	}
+
+	public void initializeIssue() {
+		issues.clear();
 	}
 
 	public static Milestone of(MilestoneCreateRequestDto milestoneCreateRequestDto) {

--- a/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
+++ b/BE/src/main/java/com/codesquad/issue04/domain/milestone/Milestone.java
@@ -22,6 +22,7 @@ import com.codesquad.issue04.domain.issue.Issue;
 import com.codesquad.issue04.web.dto.request.milestone.MilestoneCreateRequestDto;
 import com.codesquad.issue04.web.dto.request.milestone.MilestoneUpdateRequestDto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/BE/src/main/java/com/codesquad/issue04/service/MilestoneService.java
+++ b/BE/src/main/java/com/codesquad/issue04/service/MilestoneService.java
@@ -56,9 +56,10 @@ public class MilestoneService {
 
 	public Milestone deleteMilestone(Long milestoneId) {
 		Milestone deleteMilestone = findMilestoneById(milestoneId);
-		// deleteMilestone.getIssues()
-		// 	.forEach(issueRepository::delete);
-
+		deleteMilestone.getIssues().forEach(
+			issue -> issue.deleteMilestone(milestoneId)
+		);
+		deleteMilestone.initializeIssue();
 		milestoneRepository.delete(deleteMilestone);
 		return deleteMilestone;
 	}

--- a/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueDetailResponseDto.java
+++ b/BE/src/main/java/com/codesquad/issue04/web/dto/response/issue/IssueDetailResponseDto.java
@@ -12,6 +12,8 @@ import com.codesquad.issue04.domain.label.Label;
 import com.codesquad.issue04.domain.milestone.Milestone;
 import com.codesquad.issue04.domain.user.RealUser;
 import com.codesquad.issue04.web.dto.response.ResponseDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +29,7 @@ public class IssueDetailResponseDto implements ResponseDto {
 	private List<Comment> comments;
 	private Set<Label> labels;
 	private Assignees assignees;
+	@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 	private Milestone milestone;
 	private RealUser realUser;
 	private Status status;

--- a/BE/src/main/resources/db/migration/V1__CreateTable.sql
+++ b/BE/src/main/resources/db/migration/V1__CreateTable.sql
@@ -32,9 +32,8 @@ CREATE TABLE IF NOT EXISTS issue
     `created_on` DATETIME    NULL,
     `updated_on` DATETIME    NULL,
     user_id      INT         NULL,
-    milestone_id INT         NULL,
-    CONSTRAINT fk_issue_user FOREIGN KEY (user_id) REFERENCES user (id),
-    CONSTRAINT fk_issue_milestone1 FOREIGN KEY (milestone_id) REFERENCES milestone (id)
+    milestone_id INT         NULL REFERENCES milestone (id),
+    CONSTRAINT fk_issue_user FOREIGN KEY (user_id) REFERENCES user (id)
 );
 
 CREATE TABLE IF NOT EXISTS comment
@@ -83,5 +82,11 @@ CREATE TABLE IF NOT EXISTS label_has_issue
 (
     id       INT PRIMARY KEY AUTO_INCREMENT,
     label_id INT NOT NULL,
+    issue_id INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS milestone_has_issue
+(
+    milestone_id INT NOT NULL,
     issue_id INT NOT NULL
 );


### PR DESCRIPTION
## 구현한 기능
* [x] 마일스톤 삭제 기능이 정상적으로 구현되도록 설계를 수정하였다.

## 수정한 설계
* [x] 별도의 테이블을 작성하여 Issue entity에서 이를 Milestone을 생성할 때 활용하도록 구현했다.
* [x] Milestone을 삭제할 때 해당 Milestone이 참조하고 있는 Issue에 접근하여 NullMilestone을 생성한 후에 주입한다.
* [x] Milestone 객체에서 현재 RealUser 리스트의 Issue를 모두 삭제한다.
* [x] 테이블 상에 Issue가 갖는 foreign key references를 일반 references로 변경하였다.

## 오류 해결
* 오류 로그: 
```
No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS
```
* 원인 : host에 LAZY 로딩 설정이 걸려있었다. LAZY 로딩은 데이터베이스에서 Object를 가져올 때 맵핑 되어있는 다른 Object를 가져오지 않는 것이다.(혹은 나중에 필요할 때 가져오는 방법)
* Jackson은 User와 연관되어 있는 host를 serialize를 하려고 한다. 하지만 정상적인 Object가 아닌 JavaassistLazyInitializer 때문에 실패하게 된다.
```
spring.jackson.serialization.fail-on-empty-beans=false
```
* 이 한줄의 코드를 application.properties에 입력하면 에러는 없어진다. 하지만 이것은 표면적인 방법이지 문제의 원인을 근본적으로 해결하는 것이 아니다. 이 문제를 해결하기 위해서는 이 Object가 JSON 형식으로 변환할지 말지를 결정해야 한다.

### 해결 방법
* 해결방법 1. 
	* 해당 Object를 JSON 타입으로 변환을 하기 위해서는 FetchType.LAZY 설정을 지운다.
* 해결방법 2.
	* 해당 Object를 JSON으로 변환하지 않는다면, @JsonIgnore 어노테이션을 nested 객체에 붙인다.
* 해결방법 3.
	```@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})```

### 링크
* https://jhkang-tech.tistory.com/92
* https://stackoverflow.com/questions/24994440/no-serializer-found-for-class-org-hibernate-proxy-pojo-javassist-javassist
* http://blog.naver.com/PostView.nhn?blogId=rorean&logNo=221553310279&categoryNo=11&parentCategoryNo=0&viewDate=&currentPage=1&postListTopCurrentPage=1&from=postView